### PR TITLE
[nav] add test case download ability to simulator

### DIFF
--- a/simulators/nav/src/components/App.html
+++ b/simulators/nav/src/components/App.html
@@ -19,9 +19,16 @@
             <input type="number" bind:value="radius"/>
         </label></p>
         <p>
-            <label>Test Case: </label>
+            <label>Upload: </label>
             <input id="files" name="files[]" type="file"/>
         </p>
+        <p>
+            <label>Download: </label>
+            <!-- <label for="input-fileName"></label> -->
+            <input type="text" class="form-control" id="input-filename" value="textFile" placeholder="Enter file name">
+            <input type="button" id="dwn-btn" value="Download"/>
+        </p>
+
     </div>
 
     <div id="sidebar">
@@ -98,19 +105,26 @@
         {{#each rocks as rock, i}}
         <div class="display rock_display">
             <SimulatedItemDisplay
-                            title="Rock {{ i }}"
-                            item="{{ rock }}"
-                            rover="{{ odom }}"
-                            on:click='splice("rocks", i, 1)'>
+                title="Rock {{ i }}"
+                item="{{ rock }}"
+                rover="{{ odom }}"
+                on:click='splice("rocks", i, 1)'>
             </SimulatedItemDisplay>
         </div>
         {{/each}}
     </div>
 
     <script>
-        function uploadFile() {
-            current_test: test
+        function download(filename, text) {
+            var element = document.createElement('a');
+            element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+            element.setAttribute('download', filename);
+            element.style.display = 'none';
+            document.body.appendChild(element);
+            element.click();
+            document.body.removeChild(element);
         }
+
     </script>
 </div>
 
@@ -130,6 +144,7 @@
     export default {
         oncreate() {
             document.getElementById('files').addEventListener('change', this.handleFileSelect);
+            document.getElementById('dwn-btn').addEventListener('click', this.handleDownloadTest);
             app = this;
         },
 
@@ -202,7 +217,7 @@
                     default: return 'Unknown';
                 }
             },
-            
+
             latitude_min_display: (odom) => odom.latitude_min.toFixed(NUM_DIGITS),
             longitude_min_display: (odom) => odom.longitude_min.toFixed(NUM_DIGITS),
         },
@@ -223,6 +238,16 @@
                         console.log(app)
                     };
                 })(files[0]);
+            },
+
+            handleDownloadTest: function(event) {
+                var test_case_data = JSON.stringify({ waypoints: app._state.waypoints,
+                                                      rocks: app._state.rocks,
+                                                      tennis_balls: app._state.tennis_balls },
+                                                    null,
+                                                    4)
+                var filename = document.getElementById('input-filename').value + ".json";
+                download(filename, test_case_data);
             },
 
             apply_joystick: function(stick) {

--- a/simulators/nav/testing/test_dummy.json
+++ b/simulators/nav/testing/test_dummy.json
@@ -1,22 +1,37 @@
 {
-	"waypoints": [
-		{
-			"search": false,
-			"latitude_deg": 39,
-			"latitude_min": 24,
-			"longitude_deg": -110,
-			"longitude_min": -29.99,
-			"bearing_deg": 0
-		},
-		{
-			"search": true,
-			"latitude_deg": 39,
-			"latitude_min": 24.01,
-			"longitude_deg": -110,
-			"longitude_min": -29.99,
-			"bearing_deg": 0
-		}
-	],
-	"rocks": [],
-	"tennis_balls": []
+    "waypoints": [
+        {
+            "search": false,
+            "latitude_deg": 39,
+            "latitude_min": 24,
+            "longitude_deg": -110,
+            "longitude_min": -29.99,
+            "bearing_deg": 0
+        },
+        {
+            "search": true,
+            "latitude_deg": 39,
+            "latitude_min": 24.01,
+            "longitude_deg": -110,
+            "longitude_min": -29.99,
+            "bearing_deg": 0
+        }
+    ],
+    "rocks": [
+        {
+            "latitude_deg": 39,
+            "latitude_min": 24.00013489824076,
+            "longitude_deg": -110,
+            "longitude_min": -29.99511196234323
+        }
+    ],
+    "tennis_balls": [
+        {
+            "latitude_deg": 39,
+            "latitude_min": 24.0101623341468,
+            "longitude_deg": -110,
+            "longitude_min": -29.991678687830756,
+            "detected": false
+        }
+    ]
 }


### PR DESCRIPTION
This change adds the ability to download the current simulator field as a test case in the form of a json object which can be directly uploaded to the simulator to test the same exact set of waypoints, rocks, and tennis balls.