### PR TITLE
[nav] Change lcm joystick channel in nav stack

### DIFF
--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -23,7 +23,7 @@
 	"cvThresh": 3,
 
 	"navStatusChannel": "/nav_status",
-	"joystickChannel": "/drive_control",
+	"joystickChannel": "/autonomous",
 
 	"searchOrder":[0,1],
 	"searchOrderSize": 2

--- a/simulators/nav/src/main.js
+++ b/simulators/nav/src/main.js
@@ -24,7 +24,7 @@ const bridge = new LCMBridge("ws://localhost:8001",
     },
     // Message handler
     ({topic, message}) => {
-        if (topic === '/drive_control') {
+        if (topic === '/autonomous') {
             app.apply_joystick(message);
         } else if (topic === '/nav_status') {
             app.set(message);
@@ -32,7 +32,7 @@ const bridge = new LCMBridge("ws://localhost:8001",
     },
     // Subscriptions
     [{
-        'topic': '/drive_control',
+        'topic': '/autonomous',
         'type': 'Joystick'
     },
     {


### PR DESCRIPTION
This patch updates the nav stack to use 'autonomous' as the joystick lcm channel rather than 'drive_control'.