### PR TITLE
[nav] Added config option to scale bearing and driving constant

### DIFF
--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -13,6 +13,9 @@
 		"kD": 0
 	},
 
+	"bearingPower": 0.5,
+	"drivingPower": 1.0,
+
 	"turningBearingThresh": 20,
 	"drivingBearingThresh": 50,
 

--- a/onboard/nav/rover.cpp
+++ b/onboard/nav/rover.cpp
@@ -257,8 +257,10 @@ void Rover::publishJoystick( const double forwardBack, const double leftRight, c
 {
     Joystick joystick;
     joystick.dampen = -1.0; // power limit (0 = 50%, 1 = 0%, -1 = 100% power)
-    joystick.forward_back = -forwardBack;
-    joystick.left_right = leftRight;
+    double drivingPower = mRoverConfig[ "drivingPower" ].GetDouble();
+    joystick.forward_back = drivingPower = forwardBack;
+    double bearingPower = mRoverConfig[ "bearingPower" ].GetDouble();
+    joystick.left_right = bearingPower * leftRight;
     joystick.kill = kill;
     string joystickChannel = mRoverConfig[ "joystickChannel" ].GetString();
     mLcmObject.publish( joystickChannel, &joystick );

--- a/simulators/nav/src/components/SimulatorField.html
+++ b/simulators/nav/src/components/SimulatorField.html
@@ -31,7 +31,7 @@ const ROVER_FIELD_OF_VIEW = 2*Math.PI/3;
 const ROVER_DEPTH_OF_VIEW = 10;
 const CV_DEPTH = 5;
 
-const TRANSLATIONAL_SCALE = -1;
+const TRANSLATIONAL_SCALE = 1;
 const ROTATIONAL_SCALE = 2;
 
 function ensure_in_range(x, min, max) {


### PR DESCRIPTION
This change adds scaling constants to the bearing and driving components
to the joystick message. These constants can be changed in the config file.
This change also removes the negative sign on the forward_back component
of the joystick command.