### PR TITLE
[Jarvis] Revised: Jarvis exec now accepts build dirs

### DIFF
--- a/jarvis
+++ b/jarvis
@@ -61,7 +61,14 @@ if [ "$1" = "exec" ]; then
         source "${PRODUCT_ENV}/bin/activate"
         export MROVER_CONFIG="${PRODUCT_ENV}/config"
         shift
-        exec env LD_LIBRARY_PATH="${PRODUCT_ENV}/lib:${PRODUCT_ENV}/lib/x86_64-linux-gnu" "$@"
+        # Convert forward slashes to underscore
+        arg_no_slash=${1//"/"/"_"}
+        # Remove trailing underscore
+        remove_trail=${arg_no_slash%_}
+        # Replace the first argument to exec with formatted arg
+        clean_args=${@/$1/$remove_trail}
+        exec env LD_LIBRARY_PATH="${PRODUCT_ENV}/lib:${PRODUCT_ENV}/lib/x86_64-linux-gnu"\
+         $clean_args
     else
         echo "You must build something in order to be able to exec a command."
     fi

--- a/jarvis
+++ b/jarvis
@@ -61,12 +61,12 @@ if [ "$1" = "exec" ]; then
         source "${PRODUCT_ENV}/bin/activate"
         export MROVER_CONFIG="${PRODUCT_ENV}/config"
         shift
-        # Convert forward slashes to underscore
-        arg_no_slash=${1//"/"/"_"}
-        # Remove trailing underscore
-        remove_trail=${arg_no_slash%_}
-        # Replace the first argument to exec with formatted arg
-        clean_args=${@/$1/$remove_trail}
+
+        # Convert project file path to executable name
+        remove_trail=${1%/}
+        arg_no_slash=${remove_trail//"/"/"_"}
+        clean_args=${@/$1/$arg_no_slash}
+
         exec env LD_LIBRARY_PATH="${PRODUCT_ENV}/lib:${PRODUCT_ENV}/lib/x86_64-linux-gnu"\
          $clean_args
     else


### PR DESCRIPTION
replaces forward slash in first argument to exec with underscores and trims trailing underscores
should no longer interfere with successive arguments 
e.g `jarvis exec lcm_tools_echo Encoder /encoder` will behave as expected.