### PR TITLE
[cv] update LCM distance field if obstacle is detected

### DIFF
--- a/onboard/cv/main.cpp
+++ b/onboard/cv/main.cpp
@@ -164,6 +164,7 @@ int main() {
       if(obstacle_detection.bearing > 0.05 || obstacle_detection.bearing < -0.05) {
         // cout<< "bearing not zero!\n";
         obstacleMessage.detected = true;    //if an obstacle is detected in front
+        obstacleMessage.distance = obstacle_detection.center_distance; //update LCM distance field
       }
       obstacleMessage.bearing = obstacle_detection.bearing;
 


### PR DESCRIPTION
Fixes bug found during testing where obstacle distance was never actually updated when an obstacle was detected by the sliding window algorithm.