### PR TITLE
[nav-sim] Add ability to move rover and start point

### DIFF
--- a/simulators/nav/src/components/HotKeys.vue
+++ b/simulators/nav/src/components/HotKeys.vue
@@ -12,7 +12,12 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
-import { FieldItemType, Joystick, OdomFormat } from '../utils/types';
+import {
+  FieldItemType,
+  Joystick,
+  Odom,
+  OdomFormat
+} from '../utils/types';
 
 @Component({})
 export default class HotKeys extends Vue {
@@ -23,7 +28,13 @@ export default class HotKeys extends Vue {
   private readonly autonOn!:boolean;
 
   @Getter
+  private readonly currOdom!:Odom;
+
+  @Getter
   private readonly drawMode!:FieldItemType;
+
+  @Getter
+  private readonly fieldCenterOdom!:Odom;
 
   @Getter
   private readonly paused!:boolean;
@@ -38,7 +49,13 @@ export default class HotKeys extends Vue {
    * Vuex Mutations
    ************************************************************************************************/
   @Mutation
+  private readonly clearRoverPath!:()=>void;
+
+  @Mutation
   private readonly setAutonState!:(onOff:boolean)=>void;
+
+  @Mutation
+  private readonly setCurrOdom!:(newOdom:Odom)=>void;
 
   @Mutation
   private readonly setDrawMode!:(mode:FieldItemType)=>void;
@@ -53,6 +70,9 @@ export default class HotKeys extends Vue {
   private readonly setPaused!:(paused:boolean)=>void;
 
   @Mutation
+  private readonly setStartLoc!:(newStartLoc:Odom)=>void;
+
+  @Mutation
   private readonly setTakeStep!:(takeStep:boolean)=>void;
 
   @Mutation
@@ -62,10 +82,16 @@ export default class HotKeys extends Vue {
   private readonly flipSimulatePercep!:(onOff:boolean)=>void;
 
   /************************************************************************************************
+   * Private Members
+   ************************************************************************************************/
+  /* Whether or not clicking on the field recenters the field. */
+  private prevDrawMode:FieldItemType|null = null;
+
+  /************************************************************************************************
    * Local Getters/Setters
    ************************************************************************************************/
   /* Mapping of hotkeys to functions. */
-  get keymap():Record<string, ()=>void> {
+  get keymap():Record<string, (()=>void)|(Record<string, ()=>void>)> {
     return {
       'shift+enter': this.flipAutonState,
       'shift+space': this.pausePlay,
@@ -77,6 +103,12 @@ export default class HotKeys extends Vue {
       'shift+3': this.setToGateDrawMode,
       'shift+4': this.setToObstacleDrawMode,
       'shift+5': this.setToReferencePointDrawMode,
+      'shift+c': {
+        keydown: this.toggleMoveRoverModeOn,
+        keyup: this.toggleMoveRoverModeOff
+      },
+      'shift+alt+c': this.updateStartLoc,
+      'shift+ctrl+c': this.resetStartLoc,
       'shift+l': this.flipSimLoc,
       'shift+p': this.flipSimPercep,
       'shift+alt+d': this.setToDFormat,
@@ -142,6 +174,15 @@ export default class HotKeys extends Vue {
   private pausePlay():void {
     this.setPaused(!this.paused);
   } /* pausePlay() */
+
+  /* Move the rover's starting location back to the field center. */
+  private resetStartLoc():void {
+    if (!this.autonOn) {
+      this.setStartLoc(this.fieldCenterOdom);
+      this.setCurrOdom(this.fieldCenterOdom);
+      this.clearRoverPath();
+    }
+  } /* resetStartLoc() */
 
   /* Rotate through the draw modes in the forwards direction. */
   private setToNextDrawMode():void {
@@ -253,5 +294,31 @@ export default class HotKeys extends Vue {
       this.setTakeStep(true);
     }
   } /* takeStep() */
+
+  /* Switch from MOVE_ROVER draw mode back to previous draw mode. */
+  private toggleMoveRoverModeOff():void {
+    if (this.prevDrawMode === null) {
+      console.log('ERROR: Previous Draw Mode is null.');
+      return;
+    }
+    this.setDrawMode(this.prevDrawMode);
+    this.prevDrawMode = null;
+  } /* toggleMoveRoverModeOff() */
+
+  /* Switch to MOVE_ROVER draw mode and save previous draw mode. */
+  private toggleMoveRoverModeOn():void {
+    if (this.drawMode !== FieldItemType.MOVE_ROVER) {
+      this.prevDrawMode = this.drawMode;
+      this.setDrawMode(FieldItemType.MOVE_ROVER);
+    }
+  } /* toggleMoveRoverModeOn() */
+
+  /* Make the current odom the new start location. */
+  private updateStartLoc():void {
+    if (!this.autonOn) {
+      this.setStartLoc(this.currOdom);
+      this.clearRoverPath();
+    }
+  } /* updateStartLoc() */
 }
 </script>

--- a/simulators/nav/src/components/common/HeartbeatMonitor.vue
+++ b/simulators/nav/src/components/common/HeartbeatMonitor.vue
@@ -77,7 +77,7 @@ export default class HearbeatMonitor extends Vue {
   /************************************************************************************************
    * Vue Life Cycle
    ************************************************************************************************/
-  /* */
+  /* Start checking for program pulse's on start up. */
   private created():void {
     this.checkPulseInterval = window.setInterval(this.checkForPulse, HB_CHECK_INTERVAL);
   } /* created() */

--- a/simulators/nav/src/components/control_panel/DebugTools.vue
+++ b/simulators/nav/src/components/control_panel/DebugTools.vue
@@ -123,9 +123,6 @@ export default class DebugTools extends Vue {
   private readonly currSpeed!:Speeds;
 
   @Getter
-  private readonly fieldCenterOdom!:Odom;
-
-  @Getter
   private readonly fieldOfViewOptions!:FieldOfViewOptions;
 
   @Getter
@@ -139,6 +136,9 @@ export default class DebugTools extends Vue {
 
   @Getter
   private readonly simulateLoc!:boolean;
+
+  @Getter
+  private readonly startLoc!:Odom;
 
   @Getter
   private readonly takeStep!:boolean;
@@ -283,7 +283,7 @@ export default class DebugTools extends Vue {
 
   /* Reset the rover to the starting state. */
   private resetRover():void {
-    this.setCurrOdom(this.fieldCenterOdom);
+    this.setCurrOdom(this.startLoc);
     this.setAutonState(false);
     this.setPaused(false);
     this.clearRoverPath();

--- a/simulators/nav/src/components/field/Field.vue
+++ b/simulators/nav/src/components/field/Field.vue
@@ -47,7 +47,8 @@
         v-drawArTags="canvasArTags"
         v-drawRepeater="canvasRepeater"
         v-drawRover="canvasRover"
-        @click="addFieldItem"
+        @click="handleFieldClick"
+        @dblclick="handleFieldDblClick"
       />
     </div>
   </div>
@@ -135,6 +136,9 @@ export default class Field extends Vue {
   private readonly arTags!:ArTag[];
 
   @Getter
+  private readonly autonOn!:boolean;
+
+  @Getter
   private readonly canvasHeight!:number;
 
   @Getter
@@ -189,6 +193,9 @@ export default class Field extends Vue {
    * Vuex Mutations
    ************************************************************************************************/
   @Mutation
+  private readonly clearRoverPath!:()=>void;
+
+  @Mutation
   private readonly pushArTag!:(newArTag:ArTag)=>void;
 
   @Mutation
@@ -210,6 +217,9 @@ export default class Field extends Vue {
   private readonly setArTag!:(newArTags:ArTag[])=>void;
 
   @Mutation
+  private readonly setCurrOdom!:(newOdom:Odom)=>void;
+
+  @Mutation
   private readonly setFieldState!:(newState:FieldState)=>void
 
   @Mutation
@@ -217,6 +227,9 @@ export default class Field extends Vue {
 
   @Mutation
   private readonly setObstacles!:(newObstacles:Obstacle[])=>void;
+
+  @Mutation
+  private readonly setStartLoc!:(newStartLoc:Odom)=>void;
 
   @Mutation
   private readonly setWaypoints!:(newWaypoints:Waypoint[])=>void;
@@ -290,12 +303,22 @@ export default class Field extends Vue {
   /************************************************************************************************
    * Private Methods
    ************************************************************************************************/
+  /* Download a test case in JSON format with the current field items on the
+     canvas. */
+  private downloadTestCase():void {
+    const testCaseData:string = JSON.stringify(this.fieldState, null, 2);
+    const dataToDownload = `data:text/plain;charset=utf-8,${encodeURIComponent(testCaseData)}`;
+
+    this.dataToDownload.setAttribute('href', dataToDownload);
+    this.dataToDownload.setAttribute('download', `test_case_${new Date().toJSON()}.json`);
+    this.dataToDownload.click();
+    this.dataToDownload.removeAttribute('href');
+    this.dataToDownload.removeAttribute('download');
+  } /* downloadTestCase() */
+
   /* When field is clicked, add the field item corresponding to the current
      draw mode. */
-  private addFieldItem(event:MouseEvent):void {
-    /* Update scale in case of window resizing */
-    // this.updateScale();
-
+  private handleFieldClick(event:MouseEvent):void {
     const clickLoc:Point2D = {
       x: event.offsetX * PIXEL_DENSITY,
       y: event.offsetY * PIXEL_DENSITY
@@ -347,22 +370,51 @@ export default class Field extends Vue {
         break;
       }
 
+      case FieldItemType.MOVE_ROVER: {
+        this.moveRover(clickOdom);
+        break;
+      }
+
       /* no default */
     }
-  } /* addFieldItem() */
+  } /* handleFieldClick() */
 
-  /* Download a test case in JSON format with the current field items on the
-     canvas. */
-  private downloadTestCase():void {
-    const testCaseData:string = JSON.stringify(this.fieldState, null, 2);
-    const dataToDownload = `data:text/plain;charset=utf-8,${encodeURIComponent(testCaseData)}`;
+  /* When field is double-clicked, perform action corresponding to the current
+     draw mode. */
+  private handleFieldDblClick(event:MouseEvent):void {
+    const clickLoc:Point2D = {
+      x: event.offsetX * PIXEL_DENSITY,
+      y: event.offsetY * PIXEL_DENSITY
+    };
+    const clickOdom:Odom = canvasToOdom(clickLoc, this.canvasHeight, this.scale,
+                                        this.fieldCenterOdom);
 
-    this.dataToDownload.setAttribute('href', dataToDownload);
-    this.dataToDownload.setAttribute('download', `test_case_${new Date().toJSON()}.json`);
-    this.dataToDownload.click();
-    this.dataToDownload.removeAttribute('href');
-    this.dataToDownload.removeAttribute('download');
-  } /* downloadTestCase() */
+    switch (this.drawMode) {
+      case FieldItemType.MOVE_ROVER: {
+        this.moveStartLoc(clickOdom);
+        break;
+      }
+
+      /* no default */
+    }
+  } /* handleFieldDblClick() */
+
+  /* If the rover is not on, move the current odom. */
+  private moveRover(newCurrOdom:Odom):void {
+    if (!this.autonOn) {
+      this.setCurrOdom(newCurrOdom);
+      this.clearRoverPath();
+    }
+  } /* moveRover() */
+
+  /* If the rover is not on, change the starting (and current) location. */
+  private moveStartLoc(newStartLoc:Odom):void {
+    if (!this.autonOn) {
+      this.setStartLoc(newStartLoc);
+      this.setCurrOdom(newStartLoc);
+      this.clearRoverPath();
+    }
+  } /* moveStartLoc() */
 
   /* Update scale when the field size changes. */
   private updateScale():void {

--- a/simulators/nav/src/store/modules/simulatorState.ts
+++ b/simulators/nav/src/store/modules/simulatorState.ts
@@ -71,6 +71,15 @@ const state:SimulatorState = {
   simSettings: {
     simulateLoc: true,
     simulatePercep: true
+  },
+
+  startLoc: {
+    latitude_deg: 38,
+    latitude_min: 24.38,
+    longitude_deg: -110,
+    longitude_min: -47.51,
+    bearing_deg: 0,
+    speed: -1
   }
 };
 
@@ -104,13 +113,13 @@ const getters = {
 
   roverPath: (simState:SimulatorState):Odom[] => simState.path,
 
-  // roverPathOld: (simState:SimulatorState):TempPath => simState.roverPathOld,
-
   roverPathVisible: (simState:SimulatorState):boolean => simState.debugOptions.roverPathVisible,
 
   simulateLoc: (simState:SimulatorState):boolean => simState.simSettings.simulateLoc,
 
   simulatePercep: (simState:SimulatorState):boolean => simState.simSettings.simulatePercep,
+
+  startLoc: (simState:SimulatorState):Odom => simState.startLoc,
 
   takeStep: (simState:SimulatorState):boolean => simState.debugOptions.takeStep,
 
@@ -198,6 +207,10 @@ const mutations = {
 
   setRoverPathVisible: (simState:SimulatorState, onOff:boolean):void => {
     simState.debugOptions.roverPathVisible = onOff;
+  },
+
+  setStartLoc: (simState:SimulatorState, newStartLoc:Odom):void => {
+    Object.assign(simState.startLoc, newStartLoc);
   },
 
   setTakeStep: (simState:SimulatorState, takeStep:boolean):void => {

--- a/simulators/nav/src/utils/types.ts
+++ b/simulators/nav/src/utils/types.ts
@@ -45,7 +45,8 @@ export enum FieldItemType {
   OBSTACLE,
   AR_TAG,
   GATE,
-  REFERENCE_POINT
+  REFERENCE_POINT,
+  MOVE_ROVER
 }
 
 
@@ -261,6 +262,7 @@ export interface SimulatorState {
   odomFormat:OdomFormat;
   path:Odom[];
   simSettings:SimulationSettings;
+  startLoc:Odom;
 }
 
 


### PR DESCRIPTION
resolves #395

Add hotkeys to move the rover by clicking on the simulator
field, adjust the rover's starting position, and reset the
rover's starting position.