### PR TITLE
[auton] update obstacle interface

### DIFF
--- a/onboard/cv/main.cpp
+++ b/onboard/cv/main.cpp
@@ -86,7 +86,7 @@ int main() {
   rover_msgs::Obstacle obstacleMessage;
   arTags[0].distance = -1;
   arTags[1].distance = -1;
-  obstacleMessage.detected = false;
+  obstacleMessage.distance = -1;
 
   //tag detection stuff
   TagDetector detector;
@@ -130,7 +130,7 @@ int main() {
         arTags[0].id = tagPair.first.id;
         left_tag_buffer = 0;
       }
-      
+
       //first tag
       if(tagPair.second.id == -1){//no tag found
         if(right_tag_buffer <= 20){//send the buffered tag
@@ -153,7 +153,7 @@ int main() {
 
 
     /*initialize obstacle detection*/
-    obstacleMessage.detected = false;
+    obstacleMessage.distance = -1;
     #if OBSTACLE_DETECTION
       float pixelWidth = src.cols;
       //float pixelHeight = src.rows;
@@ -163,13 +163,12 @@ int main() {
       obstacle_return obstacle_detection =  avoid_obstacle_sliding_window(depth_img, src,  num_sliding_windows , roverPixWidth);
       if(obstacle_detection.bearing > 0.05 || obstacle_detection.bearing < -0.05) {
         // cout<< "bearing not zero!\n";
-        obstacleMessage.detected = true;    //if an obstacle is detected in front
         obstacleMessage.distance = obstacle_detection.center_distance; //update LCM distance field
       }
       obstacleMessage.bearing = obstacle_detection.bearing;
 
       #if PERCEPTION_DEBUG
-      // cout << "Turn " << obstacleMessage.bearing << ", detected " << (bool)obstacleMessage.detected<< endl;
+      // cout << "Turn " << obstacleMessage.bearing << ", distance " << (bool)obstacleMessage.distance << endl;
       #endif
 
     #endif

--- a/onboard/nav/obstacle_avoidance/simpleAvoidance.cpp
+++ b/onboard/nav/obstacle_avoidance/simpleAvoidance.cpp
@@ -26,7 +26,7 @@ NavState SimpleAvoidance::executeTurnAroundObs( Rover* phoebe,
     {
         return NavState::TurnToTarget;
     }
-    if( !phoebe->roverStatus().obstacle().detected )
+    if( !isObstacleDetected( phoebe ) )
     {
         double distanceAroundObs = mOriginalObstacleDistance /
                                    cos( fabs( degreeToRadian( mOriginalObstacleAngle ) ) );
@@ -56,7 +56,7 @@ NavState SimpleAvoidance::executeTurnAroundObs( Rover* phoebe,
 // ( original waypoint is the waypoint before obstacle avoidance was triggered )
 NavState SimpleAvoidance::executeDriveAroundObs( Rover* phoebe )
 {
-    if( phoebe->roverStatus().obstacle().detected )
+    if( isObstacleDetected( phoebe ) )
     {
         if( phoebe->roverStatus().currentState() == NavState::DriveAroundObs )
         {
@@ -99,6 +99,5 @@ Odometry SimpleAvoidance::createAvoidancePoint( Rover* phoebe, const double dist
     avoidancePoint.longitude_min = ( totalLongitudeMinutes - ( ( (int) totalLongitudeMinutes) / 60 ) * 60 );
 
     return avoidancePoint;
-
 
 } // createAvoidancePoint()

--- a/onboard/nav/obstacle_avoidance/simpleAvoidance.hpp
+++ b/onboard/nav/obstacle_avoidance/simpleAvoidance.hpp
@@ -4,9 +4,9 @@
 #include "obstacleAvoidanceStateMachine.hpp"
 
 // This class implements the logic for the simple obstacle avoidance algorithm.
-// If an obstacle is seen, create an avoidance point using trigonometry with the angle turned and 
+// If an obstacle is seen, create an avoidance point using trigonometry with the angle turned and
 // distance from obstacle.
-class SimpleAvoidance : public ObstacleAvoidanceStateMachine 
+class SimpleAvoidance : public ObstacleAvoidanceStateMachine
 {
 public:
     SimpleAvoidance( StateMachine* roverStateMachine );

--- a/onboard/nav/rover.cpp
+++ b/onboard/nav/rover.cpp
@@ -342,7 +342,7 @@ void Rover::publishJoystick( const double forwardBack, const double leftRight, c
 // otherwise.
 bool Rover::isEqual( const Obstacle& obstacle1, const Obstacle& obstacle2 ) const
 {
-    if( obstacle1.detected == obstacle2.detected &&
+    if( obstacle1.distance == obstacle2.distance &&
         obstacle1.bearing == obstacle2.bearing )
     {
         return true;

--- a/onboard/nav/search/searchStateMachine.cpp
+++ b/onboard/nav/search/searchStateMachine.cpp
@@ -278,12 +278,6 @@ NavState SearchStateMachine::executeDriveToTarget( Rover* phoebe, const rapidjso
     return NavState::TurnToTarget;
 } // executeDriveToTarget()
 
-// Returns true if an obstacle is detected, false otherwise.
-bool SearchStateMachine::isObstacleDetected( Rover* phoebe ) const
-{
-    return phoebe->roverStatus().obstacle().detected;
-} // isObstacleDetected()
-
 // Sets last known target angle, so if target is lost, we
 // continue to turn to that angle
 void SearchStateMachine::updateTargetAngle( double bearing )

--- a/onboard/nav/search/searchStateMachine.hpp
+++ b/onboard/nav/search/searchStateMachine.hpp
@@ -46,8 +46,6 @@ private:
 
     NavState executeDriveToTarget( Rover* phoebe, const rapidjson::Document& roverConfig );
 
-    bool isObstacleDetected( Rover* phoebe ) const;
-
     void updateTargetAngle( double bearing );
 
     void updateTurnToTargetRoverAngle( double bearing );

--- a/onboard/nav/stateMachine.cpp
+++ b/onboard/nav/stateMachine.cpp
@@ -391,7 +391,7 @@ NavState StateMachine::executeDrive()
         return NavState::RadioRepeaterTurn;
     }
 
-    if( isObstacleDetected() && !isWaypointReachable( distance ) )
+    if( isObstacleDetected( mPhoebe ) && !isWaypointReachable( distance ) )
     {
         mObstacleAvoidanceStateMachine->updateObstacleElements( getOptimalAvoidanceAngle(),
                                                                 getOptimalAvoidanceDistance() );
@@ -486,12 +486,6 @@ string StateMachine::stringifyNavState() const
     return navStateNames.at( mPhoebe->roverStatus().currentState() );
 } // stringifyNavState()
 
-// Returns true if an obstacle is detected, false otherwise.
-bool StateMachine::isObstacleDetected() const
-{
-    return mPhoebe->roverStatus().obstacle().detected;
-} // isObstacleDetected()
-
 // Returns the optimal angle to avoid the detected obstacle.
 double StateMachine::getOptimalAvoidanceAngle() const
 {
@@ -534,7 +528,6 @@ void StateMachine::addRepeaterDropPoint()
 
     mPhoebe->roverStatus().path().push_front(way);
 } // addRepeaterDropPoint
-
 
 // TODOS:
 // [drive to target] obstacle and target

--- a/onboard/nav/stateMachine.hpp
+++ b/onboard/nav/stateMachine.hpp
@@ -83,8 +83,6 @@ private:
 
     string stringifyNavState() const;
 
-    bool isObstacleDetected() const;
-
     double getOptimalAvoidanceAngle() const;
 
     double getOptimalAvoidanceDistance() const;

--- a/onboard/nav/utilities.cpp
+++ b/onboard/nav/utilities.cpp
@@ -153,3 +153,9 @@ bool isLocationReachable( Rover* phoebe, const rapidjson::Document& roverConfig,
 
     return isReachable;
 } // isLocationReachable()
+
+// Returns true if an obstacle is detected, false otherwise.
+bool isObstacleDetected( Rover* phoebe )
+{
+    return phoebe->roverStatus().obstacle().distance >= 0;
+} // isObstacleDetected()

--- a/onboard/nav/utilities.hpp
+++ b/onboard/nav/utilities.hpp
@@ -36,4 +36,6 @@ bool isTargetReachable( Rover* phoebe, const rapidjson::Document& roverConfig );
 
 bool isLocationReachable( Rover* phoebe, const rapidjson::Document& roverConfig, const double locDist, const double distThresh );
 
+bool isObstacleDetected( Rover* phoebe );
+
 #endif // NAV_UTILITES

--- a/rover_msgs/Obstacle.lcm
+++ b/rover_msgs/Obstacle.lcm
@@ -1,7 +1,6 @@
 package rover_msgs;
 
 struct Obstacle {
-	boolean detected;
-	double bearing; // from straight ahead	
+	double bearing; // from straight ahead
 	double distance; // from straight ahead
 }

--- a/simulators/nav/src/components/perception/obstacle_detector.ts
+++ b/simulators/nav/src/components/perception/obstacle_detector.ts
@@ -239,7 +239,6 @@ export default class ObstacleDetector {
     }
 
     return {
-      detected: false,
       distance: this.obsDist,
       bearing: angle
     };
@@ -281,7 +280,6 @@ export default class ObstacleDetector {
     }
 
     return {
-      detected: false, /* deprecated so always false */
       distance: this.obsDist, /* Will be -1 if okay to go straight ahead (i.e. bearing = 0) */
       bearing: calcRelativeBearing(this.zedOdom.bearing_deg, angle)
     };

--- a/simulators/nav/src/store/modules/roverState.ts
+++ b/simulators/nav/src/store/modules/roverState.ts
@@ -39,7 +39,6 @@ const state:RoverState = {
   },
 
   obstacleMessage: {
-    detected: false, /* this will be deprecated so don't use */
     distance: -1,
     bearing: 0
   },

--- a/simulators/nav/src/utils/types.ts
+++ b/simulators/nav/src/utils/types.ts
@@ -130,7 +130,6 @@ export interface Obstacle {
 /* Interface representing the Obstacle LCM. This must be the same as the
    Obstacle LCM. */
 export interface ObstacleMessage {
-  detected:boolean; /* this will be deprecated so don't use */
   distance:number; /* meters from rover */
   bearing:number; /* degrees from rover */
 }


### PR DESCRIPTION
resolves #355 and #356 

This commit updates the interaction between `onboard/nav` and `onboard/cv` in regards to `Obstacle` LCM messages. It also deprecates the `detected` variable in the `Obstacle` LCM in favor of using the value of the `distance` variable.

- `detected` boolean was removed from lcm
- `detected` boolean was removed from `simulators/nav`
-in nav code, `isObstacleDetected` function was created in `utilities.cpp` that
interprets a -1 obstacle distance as no obstacle detected
-cv code was updated to send distance = -1 when no obstacle
detected