### PR TITLE
[auton] update sim functionality for integration branch

### DIFF
--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -24,7 +24,7 @@
 	{
 		"turningBearing": 20,
 		"drivingBearing": 50,
-		"waypointDistance": 100.0,
+		"waypointDistance": 2.0,
 		"targetDistance": 1.0,
 		"minTurningEffort": 0.25,
 		"gateCenteredAngleDiff": 20

--- a/simulators/nav/src/components/perception/obstacle_detector.ts
+++ b/simulators/nav/src/components/perception/obstacle_detector.ts
@@ -238,11 +238,20 @@ export default class ObstacleDetector {
       angle = intervalHeap.maxOccupied + (minIntervalSize / 2);
     }
 
-    return {
-      detected: false,
-      distance: this.obsDist,
-      bearing: angle
-    };
+    if (this.obsDist >= 0) {
+      return {
+        detected: true, /* deprecated so always false */
+        distance: this.obsDist, /* Will be -1 if okay to go straight ahead (i.e. bearing = 0) */
+        bearing: angle
+      };
+    }
+    else {
+      return {
+        detected: false, /* deprecated so always false */
+        distance: this.obsDist, /* Will be -1 if okay to go straight ahead (i.e. bearing = 0) */
+        bearing: angle
+      };
+    }
   } /* computeObsMsg() */
 
   /************************************************************************************************
@@ -279,12 +288,20 @@ export default class ObstacleDetector {
         return null;
       }
     }
-
-    return {
-      detected: false, /* deprecated so always false */
-      distance: this.obsDist, /* Will be -1 if okay to go straight ahead (i.e. bearing = 0) */
-      bearing: calcRelativeBearing(this.zedOdom.bearing_deg, angle)
-    };
+    if (this.obsDist >= 0) {
+      return {
+        detected: true, /* deprecated so always false */
+        distance: this.obsDist, /* Will be -1 if okay to go straight ahead (i.e. bearing = 0) */
+        bearing: calcRelativeBearing(this.zedOdom.bearing_deg, angle)
+      };
+    }
+    else {
+      return {
+        detected: false, /* deprecated so always false */
+        distance: this.obsDist, /* Will be -1 if okay to go straight ahead (i.e. bearing = 0) */
+        bearing: calcRelativeBearing(this.zedOdom.bearing_deg, angle)
+      };
+    }
   } /* isPathClear() */
 
   /* Is obs in a path in the direction of angle. Note that this does not take


### PR DESCRIPTION
Previously the nav sim didn't work with auton integration code because of the deprecated obstacle lcm that is still used in auton integration code. This change will help nav test code that is currently on the branch to detect and resolve integration bugs.

When the nav-main code is eventually merged with the auton integration branch, the nav sim, nav state machine, and cv code will be updated to remove the deprecated obstacle lcm detected bool. (this update is already in nav-main)