### PR TITLE
[nav-sim] Implement ZED Gimbal

### DIFF
--- a/admin/workflow_wiki/README.md
+++ b/admin/workflow_wiki/README.md
@@ -529,75 +529,75 @@ We will be continuing the demo of resolving [issue 431](https://github.com/umrov
           ```
         * *Make the actual changes to code.*
         * *Test the code changes.*
-    * I stage, commit, and push my changes.
-      ```console
-      $ git status
-      On branch hotkey-docs
-      Changes not staged for commit:
-            (use "git add <file>..." to update what will be committed)
-            (use "git restore <file>..." to discard changes in working directory)
-                  modified:   simulators/nav/README.md
-                  modified:   simulators/nav/src/README.md
-                  modified:   simulators/nav/src/components/README.md
-                  modified:   simulators/nav/src/components/hotkeys.md
+        * I stage, commit, and push my changes.
+          ```console
+          $ git status
+          On branch hotkey-docs
+          Changes not staged for commit:
+                (use "git add <file>..." to update what will be committed)
+                (use "git restore <file>..." to discard changes in working directory)
+                      modified:   simulators/nav/README.md
+                      modified:   simulators/nav/src/README.md
+                      modified:   simulators/nav/src/components/README.md
+                      modified:   simulators/nav/src/components/hotkeys.md
 
-      no changes added to commit (use "git add" and/or "git commit -a")
-      $ git commit
-      [hotkey-docs 04240fb8] Address @aswarner's comments
-       4 files changed, 16 insertions(+), 16 deletions(-)
-      $ git status
-      On branch hotkey-docs
-      Changes to be committed:
-        (use "git restore --staged <file>..." to unstage)
-                  modified:   simulators/nav/README.md
-                  modified:   simulators/nav/src/README.md
-                  modified:   simulators/nav/src/components/README.md
-                  modified:   simulators/nav/src/components/hotkeys.md
-      $ git log
-      $ git push origin hotkey-docs
-      Enumerating objects: 29, done.
-      Counting objects: 100% (27/27), done.
-      Delta compression using up to 8 threads
-      Compressing objects: 100% (12/12), done.
-      Writing objects: 100% (12/12), 1.26 KiB | 1.26 MiB/s, done.
-      Total 12 (delta 9), reused 0 (delta 0)
-      remote: Resolving deltas: 100% (9/9), completed with 8 local objects.
-      To github.com:amverni/mrover-workspace.git
-         ec43ea6b..04240fb8  hotkey-docs -> hotkey-docs
-      ```
-      My commit message:
-      ```console
-       1 Address @aswarner's comments
-       2 # Please enter the commit message for your changes. Lines starting
-       3 # with '#' will be ignored, and an empty message
-       4 #
-       5 # On branch hotkey-docs
-       6 # Changes to be committed:
-       7 #   modified:   simulators/nav/README.md
-       8 #   modified:   simulators/nav/src/README.md
-       9 #   modified:   simulators/nav/src/components/README.md
-      10 #   modified:   simulators/nav/src/components/hotkeys.md
-      11 #
-      ```
+          no changes added to commit (use "git add" and/or "git commit -a")
+          $ git commit
+          [hotkey-docs 04240fb8] Address @aswarner's comments
+           4 files changed, 16 insertions(+), 16 deletions(-)
+          $ git status
+          On branch hotkey-docs
+          Changes to be committed:
+            (use "git restore --staged <file>..." to unstage)
+                      modified:   simulators/nav/README.md
+                      modified:   simulators/nav/src/README.md
+                      modified:   simulators/nav/src/components/README.md
+                      modified:   simulators/nav/src/components/hotkeys.md
+          $ git log
+          $ git push origin hotkey-docs
+          Enumerating objects: 29, done.
+          Counting objects: 100% (27/27), done.
+          Delta compression using up to 8 threads
+          Compressing objects: 100% (12/12), done.
+          Writing objects: 100% (12/12), 1.26 KiB | 1.26 MiB/s, done.
+          Total 12 (delta 9), reused 0 (delta 0)
+          remote: Resolving deltas: 100% (9/9), completed with 8 local objects.
+          To github.com:amverni/mrover-workspace.git
+             ec43ea6b..04240fb8  hotkey-docs -> hotkey-docs
+          ```
+          My commit message:
+          ```console
+           1 Address @aswarner's comments
+           2 # Please enter the commit message for your changes. Lines starting
+           3 # with '#' will be ignored, and an empty message
+           4 #
+           5 # On branch hotkey-docs
+           6 # Changes to be committed:
+           7 #   modified:   simulators/nav/README.md
+           8 #   modified:   simulators/nav/src/README.md
+           9 #   modified:   simulators/nav/src/components/README.md
+          10 #   modified:   simulators/nav/src/components/hotkeys.md
+          11 #
+          ```
 
-      The git log:
-      ```console
-      commit 04240fb816aa1fc839f49c50c9b7060742281947 (HEAD -> hotkey-docs)
-      Author: Andrew Vernier <amverni@umich.edu>
-      Date:   Thu Nov 24 09:18:42 2020 -0500
+          The git log:
+          ```console
+          commit 04240fb816aa1fc839f49c50c9b7060742281947 (HEAD -> hotkey-docs)
+          Author: Andrew Vernier <amverni@umich.edu>
+          Date:   Thu Nov 24 09:18:42 2020 -0500
 
-          Address @aswarner's comments
+              Address @aswarner's comments
 
-      commit 0858f71ac7270e91d25f281a54c5cf5382e4a6f7
-      Merge: ec43ea6b 4e18182bbd
-      Author: Andrew Vernier <amverni@umich.edu>
-      Date:   Thu Nov 24 09:13:28 2020 -0500
+          commit 0858f71ac7270e91d25f281a54c5cf5382e4a6f7
+          Merge: ec43ea6b 4e18182bbd
+          Author: Andrew Vernier <amverni@umich.edu>
+          Date:   Thu Nov 24 09:13:28 2020 -0500
 
-          Merge branch 'main' of https://github.com/umrover/mrover-workspace into hotkey-docs
+              Merge branch 'main' of https://github.com/umrover/mrover-workspace into hotkey-docs
 
-      commit 4e182bbd62fe388a630a98a6b863ebdf260f8f29 (upstream/main)
-      ...
-      ```
+          commit 4e182bbd62fe388a630a98a6b863ebdf260f8f29 (upstream/main)
+          ...
+          ```
     * I now get 3 approvals and pass the automated checks, so I move on to step 3.
 
 3. Merge code.

--- a/base_station/gui/src/components/LCMEcho.vue
+++ b/base_station/gui/src/components/LCMEcho.vue
@@ -94,8 +94,8 @@
           '/target_list': false,
           '/temperature': false,
           '/tennis_ball': false,
-          '/zed_gimbal_command': false,
-          '/zed_gimbal_position': false
+          '/zed_gimbal_cmd': false,
+          '/zed_gimbal_data': false
         },
         subscriptions: [
           {'topic': '/arm_toggles_button_data', 'type': 'ArmToggles'},
@@ -142,8 +142,8 @@
           {'topic': '/imu', 'type': 'IMU'},
           {'topic': '/gps', 'type': 'GPS'},
           {'topic': '/microscope', 'type': 'Microscope'},
-          {'topic': '/zed_gimbal_command', 'type': 'ZedGimbalPosition'},
-          {'topic': '/zed_gimbal_position', 'type': 'ZedGimbalPosition'}
+          {'topic': '/zed_gimbal_cmd', 'type': 'ZedGimbalPosition'},
+          {'topic': '/zed_gimbal_data', 'type': 'ZedGimbalPosition'}
         ]
       }
     },

--- a/base_station/gui/src/components/LCMEcho.vue
+++ b/base_station/gui/src/components/LCMEcho.vue
@@ -142,7 +142,7 @@
           {'topic': '/imu', 'type': 'IMU'},
           {'topic': '/gps', 'type': 'GPS'},
           {'topic': '/microscope', 'type': 'Microscope'},
-          {'topic': 'zed_gimbal_command', 'type': 'ZedGimbalCommand'},
+          {'topic': 'zed_gimbal_command', 'type': 'ZedGimbalPosition'},
           {'topic': 'zed_gimbal_position', 'type': 'ZedGimbalPosition'}
         ]
       }

--- a/base_station/gui/src/components/LCMEcho.vue
+++ b/base_station/gui/src/components/LCMEcho.vue
@@ -142,8 +142,8 @@
           {'topic': '/imu', 'type': 'IMU'},
           {'topic': '/gps', 'type': 'GPS'},
           {'topic': '/microscope', 'type': 'Microscope'},
-          {'topic': 'zed_gimbal_command', 'type': 'ZedGimbalPosition'},
-          {'topic': 'zed_gimbal_position', 'type': 'ZedGimbalPosition'}
+          {'topic': '/zed_gimbal_command', 'type': 'ZedGimbalPosition'},
+          {'topic': '/zed_gimbal_position', 'type': 'ZedGimbalPosition'}
         ]
       }
     },

--- a/base_station/gui/src/components/LCMEcho.vue
+++ b/base_station/gui/src/components/LCMEcho.vue
@@ -93,8 +93,9 @@
           '/set_demand': false,
           '/target_list': false,
           '/temperature': false,
-          '/tennis_ball': false
-
+          '/tennis_ball': false,
+          '/zed_gimbal_command': false,
+          '/zed_gimbal_position': false
         },
         subscriptions: [
           {'topic': '/arm_toggles_button_data', 'type': 'ArmToggles'},
@@ -103,11 +104,9 @@
           {'topic': '/auton', 'type': 'AutonState'},
           {'topic': '/camera_servos', 'type': 'CameraServos'},
           {'topic': '/course', 'type': 'Course'},
-          // {'topic': '', 'type': 'CurrentDraw'},
           {'topic': '/debugMessage', 'type': 'DebugMessage'},
           {'topic': '/drive_vel_cmd', 'type': 'DriveVelCmd'},
           {'topic': '/encoder', 'type': 'Encoder'},
-          // {'topic': '', 'type': 'Heartbeat'},
           {'topic': '/gimbal_control', 'type': 'Keyboard'},
           {'topic': '/gimbal_openloop_cmd', 'type': 'GimbalCmd'},
           {'topic': '/hand_openloop_cmd', 'type': 'HandCmd'},
@@ -142,7 +141,9 @@
           {'topic': '/tennis_ball', 'type': 'TennisBall'},
           {'topic': '/imu', 'type': 'IMU'},
           {'topic': '/gps', 'type': 'GPS'},
-          {'topic': '/microscope', 'type': 'Microscope'}
+          {'topic': '/microscope', 'type': 'Microscope'},
+          {'topic': 'zed_gimbal_command', 'type': 'ZedGimbalCommand'},
+          {'topic': 'zed_gimbal_position', 'type': 'ZedGimbalPosition'}
         ]
       }
     },

--- a/base_station/gui/src/static/rover_msgs.json
+++ b/base_station/gui/src/static/rover_msgs.json
@@ -858,6 +858,12 @@
             "y"
         ]
     ],
+    "ZedGimbalPosition": [
+        [
+            "double",
+            "angle"
+        ]
+    ],
     "message_types": [
         "ArmPosition",
         "ArmToggles",
@@ -913,6 +919,7 @@
         "TestEnable",
         "Waypoint",
         "WheelSpeeds",
-        "Xbox"
+        "Xbox",
+        "ZedGimbalPosition"
     ]
 }

--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -48,8 +48,8 @@
 		"repeaterDropInitChannel": "/rr_drop_init",
 		"repeaterDropCompleteChannel": "/rr_drop_complete",
 		"joystickChannel": "/autonomous",
-		"zedGimbalCommand": "/zed_gimbal_command",
-		"zedGimbalPosition": "/zed_gimbal_position"
+		"zedGimbalCommand": "/zed_gimbal_cmd",
+		"zedGimbalPosition": "/zed_gimbal_data"
 	},
 
 	"radioRepeaterThresholds":

--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -47,7 +47,9 @@
 		"navStatusChannel": "/nav_status",
 		"repeaterDropInitChannel": "/rr_drop_init",
 		"repeaterDropCompleteChannel": "/rr_drop_complete",
-		"joystickChannel": "/autonomous"
+		"joystickChannel": "/autonomous",
+		"zedGimbalCommand": "/zed_gimbal_command",
+		"zedGimbalPosition": "/zed_gimbal_position"
 	},
 
 	"radioRepeaterThresholds":

--- a/rover_msgs/ZedGimbalCommand.lcm
+++ b/rover_msgs/ZedGimbalCommand.lcm
@@ -1,0 +1,5 @@
+package rover_msgs;
+
+struct ZedGimbalCommand {
+    double heading; // angle from north, 0-360
+}

--- a/rover_msgs/ZedGimbalCommand.lcm
+++ b/rover_msgs/ZedGimbalCommand.lcm
@@ -1,5 +1,0 @@
-package rover_msgs;
-
-struct ZedGimbalCommand {
-    double heading; // angle from north, 0-360
-}

--- a/rover_msgs/ZedGimbalPosition.lcm
+++ b/rover_msgs/ZedGimbalPosition.lcm
@@ -2,5 +2,5 @@ package rover_msgs;
 
 // Position for ZED gimbal
 struct ZedGimbalPosition {
-    double angle; // absolute angle from rover's heading, -180 to 180
+    double angle; // absolute angle from rover's heading, [-180, 180]
 }

--- a/rover_msgs/ZedGimbalPosition.lcm
+++ b/rover_msgs/ZedGimbalPosition.lcm
@@ -1,0 +1,5 @@
+package rover_msgs;
+
+struct ZedGimbalPosition.lcm {
+    double angle; // absolute angle to turn ZED to from north, -180 to 180
+}

--- a/rover_msgs/ZedGimbalPosition.lcm
+++ b/rover_msgs/ZedGimbalPosition.lcm
@@ -2,5 +2,5 @@ package rover_msgs;
 
 // Position for ZED gimbal
 struct ZedGimbalPosition {
-    double heading; // absolute angle from north, -180 to 180
+    double angle; // absolute angle from rover's heading, -180 to 180
 }

--- a/rover_msgs/ZedGimbalPosition.lcm
+++ b/rover_msgs/ZedGimbalPosition.lcm
@@ -1,5 +1,6 @@
 package rover_msgs;
 
-struct ZedGimbalPosition.lcm {
-    double angle; // absolute angle to turn ZED to from north, -180 to 180
+// Position for ZED gimbal
+struct ZedGimbalPosition {
+    double heading; // absolute angle from north, -180 to 180
 }

--- a/simulators/nav/src/components/NavSimulator.vue
+++ b/simulators/nav/src/components/NavSimulator.vue
@@ -47,7 +47,10 @@ import fnvPlus from 'fnv-plus';
 import { Component, Vue, Watch } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { RADIO } from '../utils/constants';
-import { applyJoystickCmdUtil, applyZedGimbalCmdUtil } from '../utils/utils';
+import {
+  applyJoystickCmdUtil,
+  applyZedGimbalCmdUtil
+} from '../utils/utils';
 import {
   Joystick,
   NavStatus,

--- a/simulators/nav/src/components/NavSimulator.vue
+++ b/simulators/nav/src/components/NavSimulator.vue
@@ -47,7 +47,7 @@ import fnvPlus from 'fnv-plus';
 import { Component, Vue, Watch } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { RADIO } from '../utils/constants';
-import { applyJoystick as applyJoystickUtil } from '../utils/utils';
+import { applyJoystickCmdUtil, applyZedGimbalCmdUtil } from '../utils/utils';
 import {
   Joystick,
   NavStatus,
@@ -55,7 +55,8 @@ import {
   Odom,
   Speeds,
   TargetListMessage,
-  Waypoint
+  Waypoint,
+  ZedGimbalPosition
 } from '../utils/types';
 import ControlPanel from './control_panel/ControlPanel.vue';
 import Field from './field/Field.vue';
@@ -71,7 +72,7 @@ import Perception from './perception/Perception.vue';
  * Constants
  **************************************************************************************************/
 /* Frequency in milliseconds to publish outgoing LCM messages at. */
-const TIME_INTERVAL = 100;
+const TIME_INTERVAL_MILLI = 100;
 
 /* Number of milliseconds in a 1 second. */
 const ONE_SECOND_MILLI = 1000;
@@ -146,6 +147,12 @@ export default class NavSimulator extends Vue {
   @Getter
   private readonly waypoints!:Waypoint[];
 
+  @Getter
+  private readonly zedGimbalCmd!:ZedGimbalPosition;
+
+  @Getter
+  private readonly zedGimbalPos!:ZedGimbalPosition;
+
   /************************************************************************************************
    * Vuex Mutations
    ************************************************************************************************/
@@ -184,6 +191,12 @@ export default class NavSimulator extends Vue {
 
   @Mutation
   private readonly setTargetList!:(newTargetList:TargetListMessage)=>void;
+
+  @Mutation
+  private readonly setZedGimbalCmd!:(newZedGimbalCmd:ZedGimbalPosition)=>void;
+
+  @Mutation
+  private readonly setZedGimbalPos!:(newZedGimbalPos:ZedGimbalPosition)=>void;
 
   /************************************************************************************************
    * Private Members
@@ -239,13 +252,15 @@ export default class NavSimulator extends Vue {
   @Watch('paused')
   private onUnpause(paused:boolean):void {
     if (!paused) {
-      this.applyJoystick();
+      this.applyJoystickCmd();
+      this.applyZedGimbalCmd();
     }
   }
 
   @Watch('takeStep')
   private onTakeStep():void {
-    this.applyJoystick();
+    this.applyJoystickCmd();
+    this.applyZedGimbalCmd();
     this.setTakeStep(false);
   }
 
@@ -254,14 +269,22 @@ export default class NavSimulator extends Vue {
    ************************************************************************************************/
   /* Apply the current joystick message to move the rover. Update the current
      odometry based on this movement. */
-  private applyJoystick():void {
+  private applyJoystickCmd():void {
     /* if not simulating localization, nothing to do */
     if (!this.simulateLoc) {
       return;
     }
+    const deltaTimeSeconds:number = TIME_INTERVAL_MILLI / ONE_SECOND_MILLI;
+    this.setCurrOdom(applyJoystickCmdUtil(this.currOdom, this.fieldCenterOdom, this.joystick,
+                                          deltaTimeSeconds, this.currSpeed));
+  }
 
-    this.setCurrOdom(applyJoystickUtil(this.currOdom, this.fieldCenterOdom, this.joystick,
-                                       TIME_INTERVAL / ONE_SECOND_MILLI, this.currSpeed));
+  /* Apply the current ZED gimbal command. Update the ZED gimbal based on the
+     current ZED gimbal command. */
+  private applyZedGimbalCmd():void {
+    const deltaTimeSeconds:number = TIME_INTERVAL_MILLI / ONE_SECOND_MILLI;
+    this.setZedGimbalPos(applyZedGimbalCmdUtil(this.zedGimbalPos, this.zedGimbalCmd,
+                                               deltaTimeSeconds, this.currSpeed));
   }
 
   /* Drop the radio repeater. */
@@ -319,7 +342,7 @@ export default class NavSimulator extends Vue {
             left_right: msg.message.left_right
           });
           if (!this.paused) {
-            this.applyJoystick();
+            this.applyJoystickCmd();
           }
         }
         else if (msg.topic === '/nav_status') {
@@ -348,7 +371,10 @@ export default class NavSimulator extends Vue {
           }
         }
         else if (msg.topic === '/zed_gimbal_command') {
-          console.log('zed_gimbal_command message');
+          this.setZedGimbalCmd(msg.message);
+          if (!this.paused) {
+            this.applyZedGimbalCmd();
+          }
         }
         else if (msg.topic === '/debugMessage') {
           if (msg.message.isError) {
@@ -362,14 +388,14 @@ export default class NavSimulator extends Vue {
 
       /* Subscriptions */
       [
-        { topic: '/autonomous',   type: 'Joystick' },
-        { topic: '/nav_status',    type: 'NavStatus' },
-        { topic: '/obstacle',     type: 'Obstacle' },
-        { topic: '/odometry',     type: 'Odometry' },
-        { topic: '/rr_drop_init', type: 'RepeaterDropInit' },
-        { topic: '/target_list',   type: 'TargetList' },
+        { topic: '/autonomous',         type: 'Joystick' },
+        { topic: '/nav_status',         type: 'NavStatus' },
+        { topic: '/obstacle',           type: 'Obstacle' },
+        { topic: '/odometry',           type: 'Odometry' },
+        { topic: '/rr_drop_init',       type: 'RepeaterDropInit' },
+        { topic: '/target_list',        type: 'TargetList' },
         { topic: '/zed_gimbal_command', type: 'ZedGimbalPosition' },
-        { topic: '/debugMessage', type: 'DebugMessage' }
+        { topic: '/debugMessage',       type: 'DebugMessage' }
       ]
     );
 
@@ -412,7 +438,10 @@ export default class NavSimulator extends Vue {
       };
       course.hash = fnvPlus.fast1a52(JSON.stringify(course));
       this.publish('/course', course);
-    }, TIME_INTERVAL);
+
+      const zedGimbalPos:any = Object.assign(this.zedGimbalPos, { type: 'ZedGimbalPosition' });
+      this.publish('/zed_gimbal_position', zedGimbalPos);
+    }, TIME_INTERVAL_MILLI);
 
     /* eslint-enable @typescript-eslint/no-explicit-any */
   } /* created() */

--- a/simulators/nav/src/components/NavSimulator.vue
+++ b/simulators/nav/src/components/NavSimulator.vue
@@ -373,7 +373,7 @@ export default class NavSimulator extends Vue {
             this.setTargetList(msg.message.targetList);
           }
         }
-        else if (msg.topic === '/zed_gimbal_command') {
+        else if (msg.topic === '/zed_gimbal_cmd') {
           this.setZedGimbalCmd(msg.message);
           if (!this.paused) {
             this.applyZedGimbalCmd();
@@ -391,14 +391,14 @@ export default class NavSimulator extends Vue {
 
       /* Subscriptions */
       [
-        { topic: '/autonomous',         type: 'Joystick' },
-        { topic: '/nav_status',         type: 'NavStatus' },
-        { topic: '/obstacle',           type: 'Obstacle' },
-        { topic: '/odometry',           type: 'Odometry' },
-        { topic: '/rr_drop_init',       type: 'RepeaterDropInit' },
-        { topic: '/target_list',        type: 'TargetList' },
-        { topic: '/zed_gimbal_command', type: 'ZedGimbalPosition' },
-        { topic: '/debugMessage',       type: 'DebugMessage' }
+        { topic: '/autonomous',     type: 'Joystick' },
+        { topic: '/nav_status',     type: 'NavStatus' },
+        { topic: '/obstacle',       type: 'Obstacle' },
+        { topic: '/odometry',       type: 'Odometry' },
+        { topic: '/rr_drop_init',   type: 'RepeaterDropInit' },
+        { topic: '/target_list',    type: 'TargetList' },
+        { topic: '/zed_gimbal_cmd', type: 'ZedGimbalPosition' },
+        { topic: '/debugMessage',   type: 'DebugMessage' }
       ]
     );
 
@@ -443,7 +443,7 @@ export default class NavSimulator extends Vue {
       this.publish('/course', course);
 
       const zedGimbalPos:any = Object.assign(this.zedGimbalPos, { type: 'ZedGimbalPosition' });
-      this.publish('/zed_gimbal_position', zedGimbalPos);
+      this.publish('/zed_gimbal_data', zedGimbalPos);
     }, TIME_INTERVAL_MILLI);
 
     /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/simulators/nav/src/components/NavSimulator.vue
+++ b/simulators/nav/src/components/NavSimulator.vue
@@ -347,6 +347,9 @@ export default class NavSimulator extends Vue {
             this.setTargetList(msg.message.targetList);
           }
         }
+        else if (msg.topic === '/zed_gimbal_command') {
+          console.log('zed_gimbal_command message');
+        }
         else if (msg.topic === '/debugMessage') {
           if (msg.message.isError) {
             console.error(msg.message.message);
@@ -365,6 +368,7 @@ export default class NavSimulator extends Vue {
         { topic: '/odometry',     type: 'Odometry' },
         { topic: '/rr_drop_init', type: 'RepeaterDropInit' },
         { topic: '/target_list',   type: 'TargetList' },
+        { topic: '/zed_gimbal_command', type: 'ZedGimbalCommand' },
         { topic: '/debugMessage', type: 'DebugMessage' }
       ]
     );

--- a/simulators/nav/src/components/NavSimulator.vue
+++ b/simulators/nav/src/components/NavSimulator.vue
@@ -368,7 +368,7 @@ export default class NavSimulator extends Vue {
         { topic: '/odometry',     type: 'Odometry' },
         { topic: '/rr_drop_init', type: 'RepeaterDropInit' },
         { topic: '/target_list',   type: 'TargetList' },
-        { topic: '/zed_gimbal_command', type: 'ZedGimbalCommand' },
+        { topic: '/zed_gimbal_command', type: 'ZedGimbalPosition' },
         { topic: '/debugMessage', type: 'DebugMessage' }
       ]
     );

--- a/simulators/nav/src/components/control_panel/DebugTools.vue
+++ b/simulators/nav/src/components/control_panel/DebugTools.vue
@@ -95,7 +95,12 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
-import { FieldOfViewOptions, Odom, Speeds } from '../../utils/types';
+import {
+  FieldOfViewOptions,
+  Odom,
+  Speeds,
+  ZedGimbalPosition
+} from '../../utils/types';
 import Button from '../common/Button.vue';
 import Checkbox from '../common/Checkbox.vue';
 import NumberInput from '../common/NumberInput.vue';
@@ -172,6 +177,9 @@ export default class DebugTools extends Vue {
 
   @Mutation
   private readonly setTakeStep!:(takeStep:boolean)=>void;
+
+  @Mutation
+  private readonly setZedGimbalPos!:(newZedGimbalPos:ZedGimbalPosition)=>void;
 
   /************************************************************************************************
    * Local Getters/Setters
@@ -286,6 +294,7 @@ export default class DebugTools extends Vue {
     this.setCurrOdom(this.startLoc);
     this.setAutonState(false);
     this.setPaused(false);
+    this.setZedGimbalPos({ angle: 0 });
     this.clearRoverPath();
   } /* resetRover() */
 

--- a/simulators/nav/src/components/field/Field.vue
+++ b/simulators/nav/src/components/field/Field.vue
@@ -80,7 +80,8 @@ import {
   Odom,
   Point2D,
   Waypoint,
-  WaypointDrawOptions
+  WaypointDrawOptions,
+  ZedGimbalPosition
 } from '../../utils/types';
 import { canvasToOdom } from '../../utils/utils';
 import CanvasArTags from './ar_tags';
@@ -189,6 +190,9 @@ export default class Field extends Vue {
   @Getter
   private readonly waypointDrawOptions!:WaypointDrawOptions;
 
+  @Getter
+  private readonly zedGimbalPos!:ZedGimbalPosition;
+
   /************************************************************************************************
    * Vuex Mutations
    ************************************************************************************************/
@@ -283,7 +287,8 @@ export default class Field extends Vue {
   /* Object for drawing rover on canvas. */
   private get canvasRover():CanvasRover {
     return new CanvasRover(this.currOdom, this.fieldCenterOdom, this.scale, this.roverPath,
-                           this.fieldOfViewOptions, this.roverPathVisible, this.pushToRoverPath);
+                           this.fieldOfViewOptions, this.roverPathVisible, this.pushToRoverPath,
+                           this.zedGimbalPos);
   }
 
   /* Object for drawing waypoints on canvas. */

--- a/simulators/nav/src/components/field/rover.ts
+++ b/simulators/nav/src/components/field/rover.ts
@@ -5,7 +5,8 @@ import {
   FieldOfViewOptions,
   Odom,
   Point2D,
-  WheelLocs
+  WheelLocs,
+  ZedGimbalPosition
 } from '../../utils/types';
 import {
   compassToCanvasRad,
@@ -69,6 +70,9 @@ export default class CanvasRover {
   /* scale of the canvas in pixels/meter */
   private scale!:number;
 
+  /* Current position of the ZED Gimbal */
+  private zedGimbalPos!:ZedGimbalPosition;
+
   /************************************************************************************************
    * Public Methods
    ************************************************************************************************/
@@ -80,7 +84,8 @@ export default class CanvasRover {
       path:Odom[],
       fov:FieldOfViewOptions,
       pathVisible:boolean,
-      pushToPath:(currLoc:Odom)=>void
+      pushToPath:(currLoc:Odom)=>void,
+      zedGimbalPos:ZedGimbalPosition
   ) {
     this.currOdom = currOdom;
     this.canvasCent = canvasCent;
@@ -89,6 +94,7 @@ export default class CanvasRover {
     this.fov = fov;
     this.pathVisible = pathVisible;
     this.pushToPath = pushToPath;
+    this.zedGimbalPos = zedGimbalPos;
 
     this.scaledEdgeOffset = EDGE_OFFSET * this.scale;
     this.scaledEboxLen = EBOX_LEN * this.scale;
@@ -175,8 +181,8 @@ export default class CanvasRover {
     this.ctx.beginPath();
     this.ctx.moveTo(roverEyeLoc.x, roverEyeLoc.y);
     this.ctx.arc(roverEyeLoc.x, roverEyeLoc.y, this.scaledFovDepth,
-                 compassToCanvasRad(-degToRad(this.fov.angle / 2)),
-                 compassToCanvasRad(degToRad(this.fov.angle / 2)),
+                 compassToCanvasRad(degToRad((-this.fov.angle / 2) + this.zedGimbalPos.angle)),
+                 compassToCanvasRad(degToRad((this.fov.angle / 2) + this.zedGimbalPos.angle)),
                  false);
     this.ctx.lineTo(roverEyeLoc.x, roverEyeLoc.y);
     this.ctx.stroke();

--- a/simulators/nav/src/components/hotkeys.md
+++ b/simulators/nav/src/components/hotkeys.md
@@ -11,6 +11,8 @@
 | `shift+down` | Apply a single drive backward joystick command. | `HotKeys.vue` |
 | `shift+left` | Apply a single turn left joystick command. | `HotKeys.vue` |
 | `shift+right` | Apply a single turn right joystick command. | `HotKeys.vue` |
+| `shift+alt+left` | Apply a single ZED gimbal command for 1 degree to the left. | `HotKeys.vue` |
+| `shift+alt+right` | Apply a single ZED gimbal command for 1 degree to the right. | `HotKeys.vue` |
 | `shift+r` | Turn off the rover and move it to the starting location. | `DebugTools.vue` |
 || <div align="center">_Draw Module_</div> ||
 | `tab` | Switch the the next draw mode. | `HotKeys.vue` |

--- a/simulators/nav/src/components/lcm_center/LCMCenter.vue
+++ b/simulators/nav/src/components/lcm_center/LCMCenter.vue
@@ -20,6 +20,7 @@
     </div>
     <div class="row">
       <RadioRepeaterLCM />
+      <ZedGimbalLCM />
     </div>
   </div>
 </template>
@@ -35,6 +36,7 @@ import ObstacleLCM from './ObstacleLCM.vue';
 import OdometryLCM from './OdometryLCM.vue';
 import RadioRepeaterLCM from './RadioRepeaterLCM.vue';
 import TargetListLCM from './TargetListLCM.vue';
+import ZedGimbalLCM from './ZedGimbalLCM.vue';
 
 @Component({
   components: {
@@ -44,7 +46,8 @@ import TargetListLCM from './TargetListLCM.vue';
     ObstacleLCM,
     OdometryLCM,
     RadioRepeaterLCM,
-    TargetListLCM
+    TargetListLCM,
+    ZedGimbalLCM
   }
 })
 export default class LCMCenter extends Vue {}

--- a/simulators/nav/src/components/lcm_center/ObstacleLCM.vue
+++ b/simulators/nav/src/components/lcm_center/ObstacleLCM.vue
@@ -7,7 +7,7 @@
     <fieldset class="obstacle">
       <legend>Obstacle</legend>
       <p>Distance: {{ dist }} m</p>
-      <p>Bearing: {{ bear }} º</p>
+      <p>Bearing: {{ bear }}º</p>
     </fieldset>
   </div>
 </template>

--- a/simulators/nav/src/components/lcm_center/OdometryLCM.vue
+++ b/simulators/nav/src/components/lcm_center/OdometryLCM.vue
@@ -8,7 +8,7 @@
       <legend>Odometry</legend>
       <p>Latitude: {{ latitude }}</p>
       <p>Longitude: {{ longitude }}</p>
-      <p>Heading: {{ currOdom.bearing_deg }} º</p>
+      <p>Heading: {{ currOdom.bearing_deg }}º</p>
     </fieldset>
   </div>
 </template>

--- a/simulators/nav/src/components/lcm_center/TargetListLCM.vue
+++ b/simulators/nav/src/components/lcm_center/TargetListLCM.vue
@@ -7,11 +7,11 @@
     <fieldset class="target-list">
       <legend>TargetList</legend>
       <p>Target 1 Distance: {{ dist1 }} m</p>
-      <p>Target 1 Bearing: {{ bear1 }} º</p>
+      <p>Target 1 Bearing: {{ bear1 }}º</p>
       <p>Target 1 ID: {{ targetList[0].id }}</p>
       <div class="divider" />
       <p>Target 2 Distance: {{ dist2 }} m</p>
-      <p>Target 2 Bearing: {{ bear2 }} º</p>
+      <p>Target 2 Bearing: {{ bear2 }}º</p>
       <p>Target 2 ID: {{ targetList[1].id }}</p>
     </fieldset>
   </div>

--- a/simulators/nav/src/components/lcm_center/ZedGimbalLCM.vue
+++ b/simulators/nav/src/components/lcm_center/ZedGimbalLCM.vue
@@ -1,0 +1,55 @@
+<!-- This file contains the ZedGimbalLCM component which displays the ZED gimbal
+     current and desired positions. -->
+
+<!--------------------------------- Template ---------------------------------->
+<template>
+  <div class="box">
+    <fieldset class="zed-gimbal">
+      <legend>ZED Gimbal</legend>
+      <p>Current: {{ currentPos }}º, Desired: {{ desiredPos }}º</p>
+    </fieldset>
+  </div>
+</template>
+
+
+<!---------------------------------- Script ----------------------------------->
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import { Getter } from 'vuex-class';
+import { ZedGimbalPosition } from '../../utils/types';
+
+/**************************************************************************************************
+ * Constants
+ **************************************************************************************************/
+const NUM_DECIMALS = 2;
+
+@Component({})
+export default class ZedGimbalLCM extends Vue {
+  /************************************************************************************************
+   * Vuex Getters
+   ************************************************************************************************/
+  @Getter
+  private readonly zedGimbalCmd!:ZedGimbalPosition;
+
+  @Getter
+  private readonly zedGimbalPos!:ZedGimbalPosition;
+
+  /************************************************************************************************
+   * Local Getters/Setters
+   ************************************************************************************************/
+  /* Current angle of the ZED gimbal relative to rover's heading. */
+  private get currentPos():number {
+    return Number(this.zedGimbalPos.angle.toFixed(NUM_DECIMALS));
+  }
+
+  /* Desired angle of the ZED gimbal relative to rover's heading. */
+  private get desiredPos():number {
+    return Number(this.zedGimbalCmd.angle.toFixed(NUM_DECIMALS));
+  }
+}
+</script>
+
+
+<!----------------------------------------- Scoped Style ------------------------------------------>
+<style scoped>
+</style>

--- a/simulators/nav/src/components/perception/obstacle_detector.ts
+++ b/simulators/nav/src/components/perception/obstacle_detector.ts
@@ -6,7 +6,8 @@ import {
   Obstacle,
   ObstacleMessage,
   Odom,
-  Point2D
+  Point2D,
+  ZedGimbalPosition
 } from '../../utils/types';
 import {
   calcDistAndBear,
@@ -59,6 +60,9 @@ export default class ObstacleDetector {
   /* obstacles visible to the rover */
   private visibleObstacles!:Obstacle[];
 
+  /* position of the ZED's gimbal */
+  private zedGimbalPos!:ZedGimbalPosition;
+
   /* location of the ZED (i.e. rover's eyes) */
   private zedOdom!:Odom;
 
@@ -68,6 +72,7 @@ export default class ObstacleDetector {
   /* Initialize ObstacleDetector. */
   constructor(
       currOdom:Odom,
+      zedGimbalPos:ZedGimbalPosition,
       obstacles:Obstacle[],
       fov:FieldOfViewOptions,
       fieldCenterOdom:Odom,
@@ -76,42 +81,14 @@ export default class ObstacleDetector {
   ) {
     this.canvasHeight = canvasHeight;
     this.currOdom = currOdom;
+    this.zedGimbalPos = zedGimbalPos;
     this.fieldCenterOdom = fieldCenterOdom;
     this.fov = fov;
     this.obstacles = obstacles;
     this.scale = scale;
 
-    this.zedOdom = calcRelativeOdom(currOdom, currOdom.bearing_deg,
-                                    ROVER.length / 2, fieldCenterOdom);
-    this.zedOdom.bearing_deg = currOdom.bearing_deg;
+    this.updateZedOdom();
   } /* constructor() */
-
-  /* Update canvas height on change. */
-  updateCanvasHeight(newCanvasHeight:number /* pixels */):void {
-    this.canvasHeight = newCanvasHeight;
-  } /* updateCanvasHeight() */
-
-  /* Update zedOdom on currOdom change. */
-  updateCurrOdom(newCurrOdom:Odom):void {
-    this.zedOdom = calcRelativeOdom(newCurrOdom, newCurrOdom.bearing_deg,
-                                    ROVER.length / 2, this.fieldCenterOdom);
-    this.zedOdom.bearing_deg = newCurrOdom.bearing_deg;
-  } /* updateCurrOdom() */
-
-  /* Update field of view options on change. */
-  updateFov(newFov:FieldOfViewOptions):void {
-    this.fov = newFov;
-  } /* updateFov() */
-
-  /* Update obstacles list on change. */
-  updateObstacles(newObstacles:Obstacle[]):void {
-    this.obstacles = newObstacles;
-  } /* updateObstacles() */
-
-  /* Update canvas field scale on change. */
-  updateScale(newScale:number):void {
-    this.scale = newScale;
-  } /* updateScale() */
 
   /* Calculate the Obstacle LCM message. */
   computeObsMsg():ObstacleMessage {
@@ -243,6 +220,38 @@ export default class ObstacleDetector {
       bearing: angle
     };
   } /* computeObsMsg() */
+
+  /* Update canvas height on change. */
+  updateCanvasHeight(newCanvasHeight:number /* pixels */):void {
+    this.canvasHeight = newCanvasHeight;
+  } /* updateCanvasHeight() */
+
+  /* Update zedOdom on currOdom change. */
+  updateCurrOdom(newCurrOdom:Odom):void {
+    this.currOdom = newCurrOdom;
+    this.updateZedOdom();
+  } /* updateCurrOdom() */
+
+  /* Update field of view options on change. */
+  updateFov(newFov:FieldOfViewOptions):void {
+    this.fov = newFov;
+  } /* updateFov() */
+
+  /* Update obstacles list on change. */
+  updateObstacles(newObstacles:Obstacle[]):void {
+    this.obstacles = newObstacles;
+  } /* updateObstacles() */
+
+  /* Update canvas field scale on change. */
+  updateScale(newScale:number):void {
+    this.scale = newScale;
+  } /* updateScale() */
+
+  /* Update ZED gimbal position on change. */
+  updateZedGimbalPos(newZedGimbalPos:ZedGimbalPosition):void {
+    this.zedGimbalPos = newZedGimbalPos;
+    this.updateZedOdom();
+  }
 
   /************************************************************************************************
    * Private Methods
@@ -531,4 +540,11 @@ export default class ObstacleDetector {
       return cornerDist <= (obs.size / 2) - MIN_OBS_SIZE;
     }
   } /* isObsVisible() */
+
+  /* Calculate the odometry of the ZED */
+  private updateZedOdom():void {
+    this.zedOdom = calcRelativeOdom(this.currOdom, this.currOdom.bearing_deg,
+                                    ROVER.length / 2, this.fieldCenterOdom);
+    this.zedOdom.bearing_deg = compassModDeg(this.currOdom.bearing_deg + this.zedGimbalPos.angle);
+  } /* updateZedOdom() */
 } /* ObstacleDetector */

--- a/simulators/nav/src/components/perception/target_detector.ts
+++ b/simulators/nav/src/components/perception/target_detector.ts
@@ -7,7 +7,8 @@ import {
   Gate,
   Odom,
   TargetMessage,
-  TargetListMessage
+  TargetListMessage,
+  ZedGimbalPosition
 } from '../../utils/types';
 import {
   arTagCompare,
@@ -29,6 +30,9 @@ export default class TargetDetector {
   /* list of all ar tags on field */
   private arTags!:ArTag[];
 
+  /* Current rover GPS location */
+  private currOdom!:Odom;
+
   /* GPS point of the center of the canvas */
   private fieldCenterOdom!:Odom;
 
@@ -44,6 +48,9 @@ export default class TargetDetector {
   /* posts visible to the rover */
   private visiblePosts!:ArTag[];
 
+  /* position of the ZED's gimbal */
+  private zedGimbalPos!:ZedGimbalPosition;
+
   /* location of the ZED (i.e. rover's eyes) */
   private zedOdom!:Odom;
 
@@ -53,45 +60,22 @@ export default class TargetDetector {
   /* Initialize ObstacleDetector. */
   constructor(
       currOdom:Odom,
+      zedGimbalPos:ZedGimbalPosition,
       arTags:ArTag[],
       gates:Gate[],
       fov:FieldOfViewOptions,
       fieldCenterOdom:Odom
   ) {
+    this.currOdom = currOdom;
+    this.zedGimbalPos = zedGimbalPos;
     this.arTags = arTags;
     this.gates = gates;
     this.fov = fov;
     this.fieldCenterOdom = fieldCenterOdom;
 
     this.getPosts();
-    this.zedOdom = calcRelativeOdom(currOdom, currOdom.bearing_deg,
-                                    ROVER.length / 2, fieldCenterOdom);
-    this.zedOdom.bearing_deg = currOdom.bearing_deg;
+    this.updateZedOdom();
   } /* constructor() */
-
-  /* Update zedOdom on currOdom change. */
-  updateCurrOdom(newCurrOdom:Odom):void {
-    this.zedOdom = calcRelativeOdom(newCurrOdom, newCurrOdom.bearing_deg,
-                                    ROVER.length / 2, this.fieldCenterOdom);
-    this.zedOdom.bearing_deg = newCurrOdom.bearing_deg;
-  } /* updateCurrOdom() */
-
-  /* Update posts list on change. */
-  updateArTags(newArTags:ArTag[]):void {
-    this.arTags = Object.assign([], newArTags);
-    this.getPosts();
-  } /* updateArTags() */
-
-  /* Update field of view options on change. */
-  updateFov(newFov:FieldOfViewOptions):void {
-    this.fov = newFov;
-  } /* updateFov() */
-
-  /* Update gates list on change. */
-  updateGates(newGates:Gate[]):void {
-    this.gates = Object.assign([], newGates);
-    this.getPosts();
-  } /* updateGates() */
 
   /* Calculate the TargetList LCM message. */
   computeTargetList():TargetListMessage {
@@ -135,7 +119,36 @@ export default class TargetDetector {
     }
 
     return [targetLeft, targetRight];
-  } /* compare_target_list() */
+  } /* computeTargetList() */
+
+  /* Update posts list on change. */
+  updateArTags(newArTags:ArTag[]):void {
+    this.arTags = Object.assign([], newArTags);
+    this.getPosts();
+  } /* updateArTags() */
+
+  /* Update zedOdom on currOdom change. */
+  updateCurrOdom(newCurrOdom:Odom):void {
+    this.currOdom = newCurrOdom;
+    this.updateZedOdom();
+  } /* updateCurrOdom() */
+
+  /* Update field of view options on change. */
+  updateFov(newFov:FieldOfViewOptions):void {
+    this.fov = newFov;
+  } /* updateFov() */
+
+  /* Update gates list on change. */
+  updateGates(newGates:Gate[]):void {
+    this.gates = Object.assign([], newGates);
+    this.getPosts();
+  } /* updateGates() */
+
+  /* Update ZED gimbal position on change. */
+  updateZedGimbalPos(newZedGimbalPos:ZedGimbalPosition):void {
+    this.zedGimbalPos = newZedGimbalPos;
+    this.updateZedOdom();
+  }
 
   /************************************************************************************************
    * Private Methods
@@ -290,4 +303,11 @@ export default class TargetDetector {
       return false;
     }
   } /* isPostVisible() */
+
+  /* Calculate the odometry of the ZED */
+  private updateZedOdom():void {
+    this.zedOdom = calcRelativeOdom(this.currOdom, this.currOdom.bearing_deg,
+                                    ROVER.length / 2, this.fieldCenterOdom);
+    this.zedOdom.bearing_deg = compassModDeg(this.currOdom.bearing_deg + this.zedGimbalPos.angle);
+  } /* updateZedOdom() */
 } /* TargetDetector */

--- a/simulators/nav/src/store/modules/roverState.ts
+++ b/simulators/nav/src/store/modules/roverState.ts
@@ -8,7 +8,8 @@ import {
   Odom,
   RoverState,
   Speeds,
-  TargetListMessage
+  TargetListMessage,
+  ZedGimbalPosition
 } from '../../utils/types';
 
 
@@ -56,7 +57,15 @@ const state:RoverState = {
       bearing: 0,
       id: -1
     }
-  ]
+  ],
+
+  zedGimbalCmd: {
+    angle: 0
+  },
+
+  zedGimbalPos: {
+    angle: 0
+  }
 };
 
 
@@ -73,7 +82,11 @@ const getters = {
 
   radioStrength: (roverState:RoverState):number => roverState.radioSignalStrength,
 
-  targetList: (roverState:RoverState):TargetListMessage => roverState.targetList
+  targetList: (roverState:RoverState):TargetListMessage => roverState.targetList,
+
+  zedGimbalCmd: (roverState:RoverState):ZedGimbalPosition => roverState.zedGimbalCmd,
+
+  zedGimbalPos: (roverState:RoverState):ZedGimbalPosition => roverState.zedGimbalPos
 };
 
 
@@ -104,6 +117,14 @@ const mutations = {
 
   setTargetList: (roverState:RoverState, newTargetList:TargetListMessage):void => {
     roverState.targetList = newTargetList;
+  },
+
+  setZedGimbalCmd: (roverState:RoverState, newZedGimbalCmd:ZedGimbalPosition):void => {
+    Object.assign(roverState.zedGimbalCmd, newZedGimbalCmd);
+  },
+
+  setZedGimbalPos: (roverState:RoverState, newZedGimbalPos:ZedGimbalPosition):void => {
+    Object.assign(roverState.zedGimbalPos, newZedGimbalPos);
   }
 };
 

--- a/simulators/nav/src/utils/constants.ts
+++ b/simulators/nav/src/utils/constants.ts
@@ -4,7 +4,8 @@
 import {
   PostConstants,
   RepeaterConstants,
-  RoverConstants
+  RoverConstants,
+  ZedConstants
 } from './types';
 
 
@@ -27,4 +28,12 @@ export const RADIO:RepeaterConstants = {
 export const ROVER:RoverConstants = {
   length: 1.25,
   width: 1.25
+};
+
+/* Define ZED and ZED gimbal constants. */
+export const ZED:ZedConstants = {
+  gimbal: {
+    minAngle: -180,
+    maxAngle: 180
+  }
 };

--- a/simulators/nav/src/utils/types.ts
+++ b/simulators/nav/src/utils/types.ts
@@ -329,6 +329,16 @@ export enum WheelPositions {
   BackRight
 }
 
+/* Interface representing the constant values used to define the ZED and ZED
+   gimbal. */
+export interface ZedConstants {
+  gimbal:{
+    minAngle:number; /* degrees */
+    maxAngle:number; /* degrees */
+  };
+}
+
+
 /* Position for ZED gimbal */
 export interface ZedGimbalPosition {
   angle:number; /* absolute angle from rover's heading, -180 to 180 */

--- a/simulators/nav/src/utils/types.ts
+++ b/simulators/nav/src/utils/types.ts
@@ -241,6 +241,8 @@ export interface RoverState {
   obstacleMessage:ObstacleMessage;
   radioSignalStrength:number;
   targetList:TargetListMessage;
+  zedGimbalCmd:ZedGimbalPosition; /* Desired position of the ZED gimbal. */
+  zedGimbalPos:ZedGimbalPosition; /* Current position of the ZED gimbal. */
 }
 
 
@@ -270,6 +272,8 @@ export interface SimulatorState {
    current speed and not the maximum speed. */
 export interface Speeds {
   drive:number; /* m/s */
+
+  /* used for both the rover turning and the ZED gimbal turning */
   turn:number; /* degrees/s */
 }
 
@@ -323,4 +327,9 @@ export enum WheelPositions {
   FrontRight,
   BackLeft,
   BackRight
+}
+
+/* Position for ZED gimbal */
+export interface ZedGimbalPosition {
+  angle:number; /* absolute angle from rover's heading, -180 to 180 */
 }

--- a/simulators/nav/src/utils/utils.ts
+++ b/simulators/nav/src/utils/utils.ts
@@ -6,7 +6,8 @@ import {
   Odom,
   OdomFormat,
   Point2D,
-  Speeds
+  Speeds,
+  ZedGimbalPosition
 } from './types';
 
 /**************************************************************************************************
@@ -30,7 +31,7 @@ const EARTH_RADIUS = 6371000.0;
 /* Calculate new gps location based a joystick command.
    CAUTION: This function assumes constant speeds over
    the time interval */
-export function applyJoystick(
+export function applyJoystickCmdUtil(
     currOdom:Odom,
     canvasCent:Odom,
     command:Joystick,
@@ -71,7 +72,22 @@ export function applyJoystick(
   nextOdom.bearing_deg = compassModDeg(currOdom.bearing_deg + deltaBear);
 
   return nextOdom;
-} /* applyJoystick() */
+} /* applyJoystickUtil() */
+
+
+/* Calculate the new ZED gimbal bearing based on the given command. */
+export function applyZedGimbalCmdUtil(
+    currentPos:ZedGimbalPosition,
+    desiredPos:ZedGimbalPosition,
+    deltaTime:number, /* seconds */
+    currSpeed:Speeds
+):ZedGimbalPosition {
+  const bearToDesired:number = currentPos.angle - desiredPos.angle;
+  const left:boolean = bearToDesired > 0;
+  const deltaBearMax:number = deltaTime * currSpeed.turn;
+  const deltaBear:number = Math.min(Math.abs(bearToDesired), deltaBearMax) * (left ? -1 : 1);
+  return { angle: currentPos.angle + deltaBear };
+} /* applyZedGimbalCmdUtil() */
 
 
 /* Compare ArTags. ArTags on the left (relative to the source) are "less than"

--- a/simulators/nav/src/utils/utils.ts
+++ b/simulators/nav/src/utils/utils.ts
@@ -1,5 +1,6 @@
 /* This file contains utility functions used throughout the application. */
 
+import { ZED } from './constants';
 import {
   ArTag,
   Joystick,
@@ -86,7 +87,14 @@ export function applyZedGimbalCmdUtil(
   const left:boolean = bearToDesired > 0;
   const deltaBearMax:number = deltaTime * currSpeed.turn;
   const deltaBear:number = Math.min(Math.abs(bearToDesired), deltaBearMax) * (left ? -1 : 1);
-  return { angle: currentPos.angle + deltaBear };
+  let newAngle:number = currentPos.angle + deltaBear;
+  if (newAngle < ZED.gimbal.minAngle) {
+    newAngle = ZED.gimbal.minAngle;
+  }
+  else if (newAngle > ZED.gimbal.maxAngle) {
+    newAngle = ZED.gimbal.maxAngle;
+  }
+  return { angle: newAngle };
 } /* applyZedGimbalCmdUtil() */
 
 


### PR DESCRIPTION
resolves #471 

This changes adds the LCM messages and channels needed for the ZED gimbal.
This change implements the simulation of the ZED gimbal in the navigation simulator and adds hotkeys for manually controlling the simulated gimbal in order to allow for richer testing.

This changes was testing by sending faked ZED gimbal command messages using the LCM send tool. Testing was done to ensure that all the affected services still built. No further integration testing was required since this was the first change related to the ZED gimbal.