### PR TITLE
SAR-critical improvements to allow rover to reach targets when posts are detected as obstacles

### DIFF
--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -31,6 +31,7 @@
 		"drivingBearing": 50,
 		"waypointDistance": 2.0,
 		"targetDistance": 1.0,
+		"tagToPostDistance": 1.5,
 		"minTurningEffort": 0.25,
 		"gateCenteredAngleDiff": 20
 	},

--- a/jetson/nav/utilities.cpp
+++ b/jetson/nav/utilities.cpp
@@ -173,6 +173,6 @@ bool isObstaclePost( Rover* phoebe, const rapidjson::Document& roverConfig )
 {
     double tagToPostThreshold = roverConfig["navThresholds"]["tagToPostDistance"].GetDouble();
     double tagToObsDist = abs( phoebe->roverStatus().obstacle().distance
-                                - phoebe->roverStatus().target().distance );
+                                - phoebe->roverStatus().leftTarget().distance );
     return tagToObsDist <= tagToPostThreshold;
 }

--- a/jetson/nav/utilities.cpp
+++ b/jetson/nav/utilities.cpp
@@ -126,11 +126,14 @@ void clear( deque<Waypoint>& aDeque )
 // Checks to see if target is reachable before hitting obstacle
 // If the x component of the distance to obstacle is greater than
 // half the width of the rover the obstacle if reachable
+// Or the obstacle is a post
 bool isTargetReachable( Rover* phoebe, const rapidjson::Document& roverConfig )
 {
     double distToTarget = phoebe->roverStatus().leftTarget().distance;
     double distThresh = roverConfig["navThresholds"]["targetDistance"].GetDouble();
-    return isLocationReachable( phoebe, roverConfig, distToTarget, distThresh );
+
+    return isLocationReachable( phoebe, roverConfig, distToTarget, distThresh ) ||
+            isObstaclePost( phoebe, roverConfig );
 } // istargetReachable()
 
 // Returns true if the rover can reach the input location without hitting the obstacle.
@@ -159,3 +162,14 @@ bool isObstacleDetected( Rover* phoebe )
 {
     return phoebe->roverStatus().obstacle().distance >= 0;
 } // isObstacleDetected()
+
+
+// returns true if the detected obstacle is likely to be a post supporting an AR tag
+// ASSUMPTION: real obstacles are not within {tagToPostThreshold} meters of the tag
+bool isObstaclePost( Rover* phoebe, const rapidjson::Document& roverConfig )
+{
+    double tagToPostThreshold = roverConfig["navThresholds"]["tagToPostDistance"].GetDouble();
+    double tagToObsDist = abs( phoebe->roverStatus().obstacle().distance
+                                - phoebe->roverStatus().target().distance );
+    return tagToObsDist <= tagToPostThreshold;
+}

--- a/jetson/nav/utilities.cpp
+++ b/jetson/nav/utilities.cpp
@@ -126,7 +126,7 @@ void clear( deque<Waypoint>& aDeque )
 // Checks to see if target is reachable before hitting obstacle
 // If the x component of the distance to obstacle is greater than
 // half the width of the rover the obstacle if reachable
-// Or the obstacle is a post
+// OR the obstacle is a post
 bool isTargetReachable( Rover* phoebe, const rapidjson::Document& roverConfig )
 {
     double distToTarget = phoebe->roverStatus().leftTarget().distance;
@@ -166,6 +166,9 @@ bool isObstacleDetected( Rover* phoebe )
 
 // returns true if the detected obstacle is likely to be a post supporting an AR tag
 // ASSUMPTION: real obstacles are not within {tagToPostThreshold} meters of the tag
+// NOTE: at beginning of subsequent early legs, we will start directly in front of a post
+// but this function will only be called when a target is detected, which is also when we have
+// already reached a waypoint, so we will treat the post as a regular obstacle
 bool isObstaclePost( Rover* phoebe, const rapidjson::Document& roverConfig )
 {
     double tagToPostThreshold = roverConfig["navThresholds"]["tagToPostDistance"].GetDouble();

--- a/jetson/nav/utilities.hpp
+++ b/jetson/nav/utilities.hpp
@@ -38,4 +38,6 @@ bool isLocationReachable( Rover* phoebe, const rapidjson::Document& roverConfig,
 
 bool isObstacleDetected( Rover* phoebe );
 
+bool isObstaclePost( Rover* phoebe, const rapidjson::Document& roverConfig );
+
 #endif // NAV_UTILITES


### PR DESCRIPTION
Added function isObstaclePost() in utilities.cpp, called by isTargetReachable(). isTargetReachable() now returns true if the obstacle does not block the target OR if the detected obstacle is within {configurable, currently 1.5} meters of the detected tag