### PR TITLE
[Nav/gimbal-turn-to-target] Adds Gimbal Based Target Verification Logic

### DIFF
--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -77,7 +77,7 @@
 		"searchWaitStepSize": 90.0,
 		"gimbalSearchWaitStepSize": 75.0,
 		"searchWaitTime": 1.0,
-		"useGimbal": true,
+		"useGimbal": false,
 		"gimbalSearchAngleMag": 150
 	}
 }

--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -27,7 +27,7 @@
 
 	"navThresholds":
 	{
-		"turningBearing": 10,
+		"turningBearing": 20,
 		"drivingBearing": 50,
 		"waypointDistance": 2.0,
 		"targetDistance": 1.0,
@@ -77,7 +77,7 @@
 		"searchWaitStepSize": 90.0,
 		"gimbalSearchWaitStepSize": 75.0,
 		"searchWaitTime": 1.0,
-		"useGimbal": false,
+		"useGimbal": true,
 		"gimbalSearchAngleMag": 150
 	}
 }

--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -27,7 +27,7 @@
 
 	"navThresholds":
 	{
-		"turningBearing": 20,
+		"turningBearing": 10,
 		"drivingBearing": 50,
 		"waypointDistance": 2.0,
 		"targetDistance": 1.0,
@@ -77,7 +77,7 @@
 		"searchWaitStepSize": 90.0,
 		"gimbalSearchWaitStepSize": 75.0,
 		"searchWaitTime": 1.0,
-		"useGimbal": false,
+		"useGimbal": true,
 		"gimbalSearchAngleMag": 150
 	}
 }

--- a/jetson/nav/search/searchStateMachine.hpp
+++ b/jetson/nav/search/searchStateMachine.hpp
@@ -44,7 +44,7 @@ private:
 
     NavState executeSearchDrive( Rover* phoebe, const rapidjson::Document& roverConfig );
 
-    NavState executeTurnToTarget( Rover* phoebe );
+    NavState executeTurnToTarget( Rover* phoebe, const rapidjson::Document& roverConfig  );
 
     NavState executeDriveToTarget( Rover* phoebe, const rapidjson::Document& roverConfig );
 

--- a/jetson/nav/stateMachine.cpp
+++ b/jetson/nav/stateMachine.cpp
@@ -301,6 +301,7 @@ bool StateMachine::isRoverReady() const
            mPhoebe->roverStatus().currentState() == NavState::RepeaterDropWait ||
            mPhoebe->roverStatus().currentState() == NavState::SearchGimbal ||
            mPhoebe->roverStatus().currentState() == NavState::GateSearchGimbal ||
+           mPhoebe->roverStatus().currentState() == NavState::TurnToTarget ||
            mPhoebe->roverStatus().currentState() == NavState::GateWait;
 
 } // isRoverReady()


### PR DESCRIPTION
Resolves #592

This PR adds code to verify targets using the gimbal. Basically, whenever we see a target, before potentially wasting energy and wearing out the motors by actually turning the rover towards it, we first turn the gimbal towards the target and then hold it for a certain amount of time to verify that the target has been actually acquired, then once it has been confirmed, we turn the rover towards the target, move the gimbal back to 0 then move onto the next searchstate.

Code was tested in the simulator by running at multiple different angles and positions and testing the full valid cycle along with testing while deleting the AR-tag while the gimbal is turning or verifying its existence.