### PR TITLE
[percep] Updated default obstacle distance

### DIFF
--- a/jetson/percep/pcl.cpp
+++ b/jetson/percep/pcl.cpp
@@ -358,9 +358,9 @@ bool PCL::CheckPath(const std::vector<std::vector<int>> &interest_points,
     #endif
 
     bool end = true; 
-    double previousDistance = DBL_MAX;
+    double previousDistance = -1;
 
-    //if there are no interest points, the distance from the last obstacle should be DBL_MAX
+    //if there are no interest points, the distance from the last obstacle should be -1
     distance = previousDistance;
     
     //Iterate through interest points
@@ -405,7 +405,7 @@ bool PCL::CheckPath(const std::vector<std::vector<int>> &interest_points,
         currentDistance = 1.0 * currentDistance / sizeOfCluster;
 
         //if the last obstacle distance from a CheckPath loop was smaller, keep the smaller value, otherwise keep the current distance value
-        if(currentDistance < previousDistance) {
+        if(currentDistance < previousDistance || (previousDistance == -1 && sizeOfCluster != 0)) {
             previousDistance = currentDistance;
             distance = previousDistance;
         }

--- a/jetson/percep/perception.hpp
+++ b/jetson/percep/perception.hpp
@@ -61,7 +61,7 @@ class obstacle_return {
   
   obstacle_return() {
     bearing = 0;
-    distance = 0;
+    distance = -1;
   }
 
   obstacle_return(double bearing_in, double distance_in) : 


### PR DESCRIPTION
## Description 
Updates default obstacle distance from `DBL_MAX` to `-1` 
## Compile Test
- [x] Offline Debug: ` ./jarvis build jetson/percep -o with_zed=false ar_detection=true obs_detection=true perception_debug=true `
  - [x] No compiler errors or warnings
- [x] Offline Silent: ` ./jarvis build jetson/percep -o with_zed=false ar_detection=true obs_detection=true perception_debug=false `
  - [x] No compiler errors or warnings
- [x] ZED Debug: ` ./jarvis build jetson/percep -o with_zed=true ar_detection=true obs_detection=true perception_debug=true `
  - [x] No compiler errors, only ZED warnings
- [x] ZED Silent: ` ./jarvis build jetson/percep -o with_zed=true ar_detection=true obs_detection=true perception_debug=false `
   - [x] No compiler errors, only ZED warnings

## Offline Debug Test
- [x] `./jarvis build jetson/percep -o with_zed=false ar_detection=true obs_detection=true perception_debug=true`
- [x] Run code against test1 image set located in perception-files repository
- Check for:
   - [x]  Left and right path are being calculated
   - [x]  Calculated bearing is reasonable given viewer output
   - [x]  AR Tag ID is 2
   - [x]  Obstacles with large width are detected
   - [x]  Path is projected around not through large obstacles
   - [x]  Short obstacles are detected
   - [x]  Steep inclines are detected as obstacles
- [x] Run code against test2 image set located in perception-files repository
- Check for:
   - [x]  Left and right path are being calculated
   - [x]  Calculated bearing is reasonable given viewer output
   - [x]  AR Tag ID is 6
   - [x]  2 AR Tags detected simultaneously
   - [x]  Obstacles with large width are detected
   - [x]  Path is projected around not through large obstacles
   - [x]  Short obstacles are detected
   - [x]  Steep inclines are detected as obstacles

## Offline Silent Test
- [x] `./jarvis build jetson/percep -o with_zed=false ar_detection=true obs_detection=true perception_debug=false`
- [x] Run `time ./jarvis exec jetson/percep` against test_case1 image set
- [x] Run `time ./jarvis exec jetson/percep` against test_case2 image set
- [ ] User value is less than or equal to \<TODO Determine Value\>

## Unit Test
- [x] ` ./jarvis build jetson/percep -o with_zed=true ar_detection=true obs_detection=true perception_debug=true `
- [x] `./jarvis exec lcm_tools_echo Obstacle "/obstacle"`
- [x] `./jarvis exec lcm_tools_echo TargetList "/target_list"`
- Test environment contains:
  - [x] 1 large obstacle ~ over 40cm tall
  - [x] 2 small obstacles ~  25cm-30cm tall
  - [x] 1 post
  - [x] 1 hill
- Test for:
  - [x] Detected large obstacle 6m away
  - [x] Detected small obstacle 2m away
  - [x] Detected clear path when 1.2m gap between 1 large and 1 small obstacle
  - [x] Left and right path are being calculated
  - [x] Calculated bearing is reasonable given viewer output of path
  - [x] AR Tag ID is the correct ID
  - [x] Obstacles with large width are detected
  - [x] Short obstacles are detected
  - [ ] FPS values don't exceed \<TODO find this value in Issue #552\>
  - [x] Obstacle.lcm in /obstacle is populated correctly
  - [x] TargetList.lcm in /target_list is populated correctly

## Integration Test
- [x] Create new branch based off of main
- [x] Checkout new branch
- [x] Cherry-Pick all PRs that need testing onto new branch
- [x] Compile all Software Packages
- [x] Run all code simultaneously
- [x] Obstacle.lcm in /obstacle is populated correctly
- [x] TargetList.lcm in /target_list is populated correctly
- [x] Sensors are Active
  - [x] Stereo Camera (ZED)
  - [x] Inertial Measurement Unit (IMU)
  - [x] Global Positioning System (GPS)
