### PR TITLE
Consolidated Packages Installed by Ansible 

### DIFF
--- a/ansible/base_station.yml
+++ b/ansible/base_station.yml
@@ -9,6 +9,7 @@
   roles:
   - jetson_dev
   - base_station_dev
+  - common_dev
   - base_station_networks
   - base_station_services
   tasks:

--- a/ansible/devbox.yml
+++ b/ansible/devbox.yml
@@ -9,3 +9,4 @@
   - base_station_dev
   - cv_dev
   - pis_dev
+  - common_dev

--- a/ansible/jetson.yml
+++ b/ansible/jetson.yml
@@ -10,5 +10,6 @@
       ansible_python_interpreter: /usr/bin/python3
   roles:
   - jetson_dev
+  - common_dev
   - jetson_networks
   - jetson_services

--- a/ansible/roles/base_station_dev/tasks/main.yml
+++ b/ansible/roles/base_station_dev/tasks/main.yml
@@ -17,37 +17,3 @@
   apt_repository:
     repo: deb https://dl.yarnpkg.com/debian/ stable main
     state: present
-
-- name: Install developer packages
-  apt: 
-    name:
-      - nodejs
-      - yarn
-      - gstreamer1.0-tools
-      - gstreamer1.0-plugins-bad
-      - gstreamer1.0-plugins-good
-      - gstreamer1.0-plugins-ugly
-      - python-gi
-      - python-gi-cairo
-      - python3-gi
-      - python3-gi-cairo
-      - gir1.2-gtk-3.0
-      - python3-venv
-      - python3-wheel
-      - python3-dev
-      - libgirepository1.0-dev
-      - build-essential
-      - libbz2-dev
-      - libreadline-dev
-      - libssl-dev
-      - zlib1g-dev
-      - libsqlite3-dev
-      - wget
-      - curl
-      - llvm
-      - libncurses5-dev
-      - libncursesw5-dev
-      - xz-utils
-      - tk-dev
-      - libcairo2-dev
-    state: present

--- a/ansible/roles/common_dev/tasks/main.yml
+++ b/ansible/roles/common_dev/tasks/main.yml
@@ -1,0 +1,38 @@
+- name: Install developer packages
+  apt: 
+    name:
+      - autoconf
+      - build-essential
+      - cmake
+      - curl
+      - gir1.2-gtk-3.0
+      - gstreamer1.0-plugins-bad
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-plugins-ugly
+      - gstreamer1.0-tools
+      - libbz2-dev
+      - libcairo2-dev
+      - libgirepository1.0-dev
+      - libglib2.0-dev
+      - libncurses5-dev
+      - libncursesw5-dev
+      - libreadline-dev
+      - libsqlite3-dev
+      - libssl-dev
+      - libtool
+      - llvm
+      - nodejs
+      - python-gi
+      - python-gi-cairo
+      - python3-dev
+      - python3-gi
+      - python3-gi-cairo
+      - python3-venv
+      - python3-wheel
+      - tk-dev
+      - wget
+      - xz-utils
+      - yarn
+      - zlib1g-dev
+    state: present
+    

--- a/ansible/roles/cv_dev/tasks/main.yml
+++ b/ansible/roles/cv_dev/tasks/main.yml
@@ -5,9 +5,5 @@
       - libboost-dev
       - imagemagick
       - libtinyxml-dev
-      - cmake
-      - build-essential
-      - nodejs
-      - yarn
       - mercurial
     state: present

--- a/ansible/roles/jetson_dev/tasks/main.yml
+++ b/ansible/roles/jetson_dev/tasks/main.yml
@@ -4,21 +4,12 @@
 - name: Install developer packages
   apt: 
     name:
-      - build-essential
-      - python3-dev
-      - python3-venv
       - python-virtualenv
-      - libglib2.0-dev
       - ninja-build
       - clang
       - clang-tidy
-      - autoconf
-      - libtool
       - libftdi-dev
       - libftdi1-dev
       - gdb
-      - cmake
-      - libcairo2-dev
-      - libgirepository1.0-dev
       - gfortran
     state: present

--- a/ansible/roles/pis_dev/tasks/main.yml
+++ b/ansible/roles/pis_dev/tasks/main.yml
@@ -1,38 +1,8 @@
 - name: Install developer packages
   apt: 
     name:
-      - python-gi
-      - python-gi-cairo
-      - python3-gi
-      - python3-gi-cairo
-      - gir1.2-gtk-3.0
-      - python3-venv
-      - python3-wheel
-      - python3-dev
-      - libgirepository1.0-dev
-      - build-essential
-      - libbz2-dev
-      - libreadline-dev
-      - libssl-dev
-      - zlib1g-dev
-      - libsqlite3-dev
-      - wget
-      - curl
-      - llvm
-      - libncurses5-dev
-      - libncursesw5-dev
-      - xz-utils
-      - tk-dev
-      - libcairo2-dev
-      - autoconf
-      - libtool
-      - libglib2.0-dev
-      - libpython3.6-dev
-      - virtualenv
-      - git
-      - python3-gst-1.0
-      - gstreamer1.0-tools
-      - gstreamer1.0-plugins-bad
-      - gstreamer1.0-plugins-good
-      - gstreamer1.0-plugins-ugly
+    - git
+    - libpython3.6-dev
+    - python3-gst-1.0
+    - virtualenv
     state: present

--- a/ansible/science.yml
+++ b/ansible/science.yml
@@ -9,6 +9,7 @@
   roles:
   - jetson_dev
   - base_station_dev
+  - common_dev
   - science_networks
   - science_services
   tasks:

--- a/ansible/vagrant_devbox.yml
+++ b/ansible/vagrant_devbox.yml
@@ -10,6 +10,7 @@
   - base_station_dev
   - cv_dev
   - pis_dev
+  - common_dev
   tasks:
   - name: Configure bashrc
     copy:


### PR DESCRIPTION
Resolves #598

These changes eliminate any repeat packages installed by ansible when calling certain playbooks. Any packages that were shared between certain ansible tasks called in the same playbook were consolidated to a common_dev task.  This does install unnecessary packages for when certain playbooks are run.

This was tested by running each playbook with the common_dev task on a new VM each time. This was also tested by doing jarvis build all on a clean VM as well. NOTE I was only able to build 13/39 projects, but this was the case for both the code straight from the mrover-workspace and my local fork (w/ common_dev and changes).
