### PR TITLE
[Nav] Gimbal: Removes redundant gimbal call

### DIFF
--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -78,7 +78,7 @@
 		"searchWaitStepSize": 90.0,
 		"gimbalSearchWaitStepSize": 75.0,
 		"searchWaitTime": 1.0,
-		"useGimbal": false,
+		"useGimbal": true,
 		"gimbalSearchAngleMag": 150
 	}
 }

--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -78,7 +78,7 @@
 		"searchWaitStepSize": 90.0,
 		"gimbalSearchWaitStepSize": 75.0,
 		"searchWaitTime": 1.0,
-		"useGimbal": true,
+		"useGimbal": false,
 		"gimbalSearchAngleMag": 150
 	}
 }

--- a/jetson/nav/gate_search/gateStateMachine.cpp
+++ b/jetson/nav/gate_search/gateStateMachine.cpp
@@ -186,7 +186,7 @@ NavState GateStateMachine::executeGateSearchGimbal()
         return NavState::GateWait;
     }
 
-    mPhoebe->publishGimbal( );
+    
 
     return NavState::GateSearchGimbal;
 }//executeGateSearchGimbal()

--- a/jetson/nav/gate_search/gateStateMachine.cpp
+++ b/jetson/nav/gate_search/gateStateMachine.cpp
@@ -145,7 +145,7 @@ NavState GateStateMachine::executeGateSearchGimbal()
 
     //set the desired_yaw to wherever the next stop on the gimbals path is
     //enter the if if the gimbal is at the next stop
-    if( mPhoebe->gimbal().setDesiredGimbalYaw( nextStop ) )
+    if( mPhoebe->sendGimbalSetpoint( nextStop ) )
     {
         //if the next stop is at the desired_yaw for the phase (150, -150, 0)
         if ( nextStop == desired_yaw )

--- a/jetson/nav/rover.cpp
+++ b/jetson/nav/rover.cpp
@@ -332,9 +332,16 @@ Gimbal& Rover::gimbal()
     return mGimbal;
 }
 
-// tells the gimbal to go to its requested location
+// tells the gimbal to go to its requested location, DEPRECATED
 void Rover::publishGimbal(){
     mGimbal.publishControlSignal( mLcmObject, mRoverConfig );
+}
+
+// sends the gimbal a desired yaw setpoint, gimbal publishes command
+bool Rover::sendGimbalSetpoint(double desired_yaw){
+    bool r = mGimbal.setDesiredGimbalYaw(desired_yaw);
+    mGimbal.publishControlSignal( mLcmObject, mRoverConfig );
+    return r;
 }
 
 

--- a/jetson/nav/rover.hpp
+++ b/jetson/nav/rover.hpp
@@ -195,6 +195,8 @@ public:
 
     void publishGimbal();
 
+    bool sendGimbalSetpoint(double desired_yaw);
+
 private:
     /*************************************************************************/
     /* Private Member Functions */

--- a/jetson/nav/search/searchStateMachine.cpp
+++ b/jetson/nav/search/searchStateMachine.cpp
@@ -162,8 +162,7 @@ NavState SearchStateMachine::executeSearchGimbal( Rover* phoebe, const rapidjson
         //we are at our stopping point for the camera so go into search gimbal wait
         return NavState::SearchWait;
     }
-    //publish gimbal lcm command
-    phoebe->publishGimbal( );
+   
 
     return NavState::SearchGimbal;
 }

--- a/jetson/nav/search/searchStateMachine.cpp
+++ b/jetson/nav/search/searchStateMachine.cpp
@@ -123,7 +123,7 @@ NavState SearchStateMachine::executeSearchGimbal( Rover* phoebe, const rapidjson
     }
     //set the desiredYaw to wherever the next stop on the gimbals path is
     //enter the if if the gimbal is at the next stop
-    if( phoebe->gimbal().setDesiredGimbalYaw( nextStop ) )
+    if( phoebe->sendGimbalSetpoint( nextStop ) )
     {   
         //if the next stop is at the desiredYaw for the phase (150, -150, 0)
         if ( nextStop == desiredYaw )


### PR DESCRIPTION
Fixes #656 

This PR fixes the problem of having to call two separate functions to move the gimbal. Previously you had to get the gimbal object from the rover then call the set desired yaw on it. And because certain objects required for sending LCM messages were only in the scope of rover.cpp, we had another method in rover.cpp to actually send that information to the gimbal class so it could publish the message

This PR creates a new method in the rover class that handles both the setting of gimbal yaw and publishing the LCM command (both through calling functions in the gimbal class). This prevents the user from having to access the gimbal object directly and also prevents the user from having to make two function calls.


This code has been tested in the simulator