### PR TITLE
[jarvis] Fixed failing build dependency of lcm_tools/send

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 services:
 - docker
 script:
-- docker pull umrover/travis
+- docker pull umrover1/travis
 - docker run --rm -it -v $(pwd):/root -v /dev/tty:/dev/ttyUSB0 -v /dev/null:/run/udev:ro
   -v /dev/tty:/dev/i2c-0 -v /dev/tty:/dev/i2c-1 -v /dev/tty:/dev/i2c-2 umrover/travis
   jarvis build -a .

--- a/lcm_tools/send/project.ini
+++ b/lcm_tools/send/project.ini
@@ -1,4 +1,4 @@
 [build]
 lang=python
 executable=True
-deps=rover_common,lcm_tools/common
+deps=rover_msgs,rover_common,lcm_tools/common


### PR DESCRIPTION
Added the rover_msgs dependency to lcm_tools/send, which was causing its build to fail, and consequently the travis check to fail. 

Normally lcm_tools/common would build before lcm_tools/send and lcm_tools/common has a dependency on rover_msgs, so it would build rover_msgs. However, lcm_tools/common started building after lcm_tools/send for some reason and we got the build bug. 

Started pulling the docker image from umrover1 dockerhub user instead of umrover user because we don't have the login credentials for the umrover user and cannot recover them