### PR TITLE
GPS Spoof for localization filter

### DIFF
--- a/config/filter/config.json
+++ b/config/filter/config.json
@@ -20,5 +20,6 @@
     "IMU_accel_filter_bias" : 0.8,
     "IMU_accel_threshold": 0.5,
 
-    "RefCoords": {"lat": 42.2766, "long": -83.7382}
+    "RefCoords": {"lat": 42.2766, "long": -83.7382},
+    "TargetCoords": {"lat": 0.0000, "long": 0.0000}
 }

--- a/jetson/filter/src/inputs.py
+++ b/jetson/filter/src/inputs.py
@@ -116,7 +116,7 @@ class AccelComponent(SensorComponent):
         self.accel_x -= grav[0]
         self.accel_y -= grav[1]
         self.accel_z -= grav[2]
-    
+
     def update(self, new_accel_sensor):
         if hasattr(new_accel_sensor, "accel_x_g"):
             self.accel_x = self.lowPass(new_accel_sensor.accel_x_g * 9.8, self.accel_x, self.filter_bias)

--- a/jetson/mp9250_bridge/main.cpp
+++ b/jetson/mp9250_bridge/main.cpp
@@ -251,7 +251,7 @@ int main(void)
     char r_buf[1024];
     bzero(r_buf,1024);
 
-    fd = uart_open(fd,"/dev/ttyS1");/*串口号/dev/ttySn,USB口号/dev/ttyUSBn */ 
+    fd = uart_open(fd,"/dev/ttyUSB0");/*串口号/dev/ttySn,USB口号/dev/ttyUSBn */ 
     if(fd == -1)
     {
         fprintf(stderr,"uart_open error\n");


### PR DESCRIPTION
Added a new filter mode that passes bearing data from the IMU and a static GPS position to odometry. We can use this for integration testing near the AR tag without going outside or having the GPS connected.