### PR TITLE
[nav] Search SM Fixes + Clean-Up

### DIFF
--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -27,9 +27,9 @@
 
 	"navThresholds":
 	{
-		"turningBearing": 20,
-		"drivingBearing": 50,
-		"waypointDistance": 2.0,
+		"turningBearing": 10,
+		"drivingBearing": 20,
+		"waypointDistance": 0.5,
 		"targetDistance": 1.0,
 		"minTurningEffort": 0.25,
 		"gateCenteredAngleDiff": 20,
@@ -70,7 +70,7 @@
 	{
 		"order": [0, 1],
 		"numSearches": 2,
-		"bailThresh": 10.0,
+		"bailThresh": 20.0,
 		"searchWaitStepSize": 90.0,
 		"searchWaitTime": 1.0
 	}

--- a/jetson/nav/rover.hpp
+++ b/jetson/nav/rover.hpp
@@ -32,11 +32,9 @@ enum class NavState
 
     // Search States
     SearchFaceNorth = 20,
-    SearchSpin = 21,
-    SearchSpinWait = 22,
-    SearchTurn = 24,
-    SearchDrive = 25,
-    ChangeSearchAlg = 26,
+    SearchTurn = 21,
+    SearchDrive = 22,
+    ChangeSearchAlg = 23,
 
     // Target Found States
     TurnToTarget = 27,

--- a/jetson/nav/search/searchStateMachine.hpp
+++ b/jetson/nav/search/searchStateMachine.hpp
@@ -57,8 +57,6 @@ private:
     /*************************************************************************/
     /* Private Member Functions */
     /*************************************************************************/
-    NavState executeSearchSpin();
-
     NavState executeRoverWait();
 
     NavState executeSearchTurn();

--- a/jetson/nav/stateMachine.cpp
+++ b/jetson/nav/stateMachine.cpp
@@ -152,8 +152,6 @@ void StateMachine::run()
             }
 
             case NavState::SearchFaceNorth:
-            case NavState::SearchSpin:
-            case NavState::SearchSpinWait:
             case NavState::SearchTurn:
             case NavState::SearchDrive:
             case NavState::TurnToTarget:
@@ -187,12 +185,12 @@ void StateMachine::run()
                     }
                     case 1:
                     {
-                        setSearcher(SearchType::LAWNMOWER, mRover, mRoverConfig);
+                        setSearcher(SearchType::SPIRALOUT, mRover, mRoverConfig);
                         break;
                     }
                     case 2:
                     {
-                        setSearcher(SearchType::SPIRALIN, mRover, mRoverConfig);
+                        setSearcher(SearchType::SPIRALOUT, mRover, mRoverConfig);
                         break;
                     }
                     default:
@@ -293,7 +291,6 @@ bool StateMachine::isRoverReady() const
 {
     return mStateChanged || // internal data has changed
            mRover->updateRover( mNewRoverStatus ) || // external data has changed
-           mRover->roverStatus().currentState() == NavState::SearchSpinWait || // continue even if no data has changed
            mRover->roverStatus().currentState() == NavState::TurnedToTargetWait || // continue even if no data has changed
            mRover->roverStatus().currentState() == NavState::RepeaterDropWait ||
            mRover->roverStatus().currentState() == NavState::GateSpinWait;
@@ -406,7 +403,7 @@ NavState StateMachine::executeDrive()
     {
         if( nextWaypoint.search )
         {
-            return NavState::SearchSpin;
+            return NavState::SearchTurn;
         }
         mRover->roverStatus().path().pop_front();
         /*if (mRover->roverStatus().currentState() == NavState::RadioRepeaterDrive)
@@ -460,8 +457,6 @@ string StateMachine::stringifyNavState() const
             { NavState::Turn, "Turn" },
             { NavState::Drive, "Drive" },
             { NavState::SearchFaceNorth, "Search Face North" },
-            { NavState::SearchSpin, "Search Spin" },
-            { NavState::SearchSpinWait, "Search Spin Wait" },
             { NavState::ChangeSearchAlg, "Change Search Algorithm" },
             { NavState::SearchTurn, "Search Turn" },
             { NavState::SearchDrive, "Search Drive" },


### PR DESCRIPTION
Removed `SearchSpin` and `SearchSpinWait` states to reduce time spent searching. Also made changes to thresholds per request so that we have more accurate control/results.