### PR TITLE
[GUI] Added zoom beyond native tilemap zoom to auton gui rover map

### DIFF
--- a/base_station/gui/src/components/RoverMapAuton.vue
+++ b/base_station/gui/src/components/RoverMapAuton.vue
@@ -88,7 +88,7 @@ export default {
       },
       tileLayerOptions: {
         maxNativeZoom: 18,
-        maxZoom: 20
+        maxZoom: 100
       }
     }
   },

--- a/base_station/gui/src/components/RoverMapAuton.vue
+++ b/base_station/gui/src/components/RoverMapAuton.vue
@@ -4,7 +4,7 @@
 
     <l-map ref="map" class="map" :zoom="15" :center="center">
       <l-control-scale :imperial="false"/>
-      <l-tile-layer :url="url" :attribution="attribution"/>
+      <l-tile-layer :url="url" :attribution="attribution" :options="tileLayerOptions"/>
       <l-marker ref="rover" :lat-lng="odomLatLng" :icon="locationIcon"/>
       <l-marker :lat-lng="waypoint.latLng" :icon="waypointIcon" v-for="(waypoint,index) in route" :key="waypoint.id" >
         <l-tooltip :options="{ permanent: 'true', direction: 'top'}"> {{ index }} </l-tooltip>
@@ -85,6 +85,10 @@ export default {
       options: {
         type: Object,
         default: () => ({})
+      },
+      tileLayerOptions: {
+        maxNativeZoom: 18,
+        maxZoom: 20
       }
     }
   },


### PR DESCRIPTION
Can now zoom in two more times to map than prior. Note that the two furthest zoom levels will have lower quality mapping due to no new tile layers being used.
![image](https://user-images.githubusercontent.com/71604997/158072266-4ded2329-df02-4e69-828b-9cc70c9b142b.png)
