### PR TITLE
[GUI] Auton map will now center on rover after first odom lcm message is sent

### DIFF
--- a/base_station/gui/src/components/RoverMapAuton.vue
+++ b/base_station/gui/src/components/RoverMapAuton.vue
@@ -82,6 +82,7 @@ export default {
       odomCount: 0,
       locationIcon: null,
       odomPath: [],
+      findRover: false,
       options: {
         type: Object,
         default: () => ({})
@@ -97,7 +98,6 @@ export default {
   },
 
   watch: {
-
     odom: function (val) {
       // Trigger every time rover odom is changed
 
@@ -105,6 +105,12 @@ export default {
       const lng = val.longitude_deg + val.longitude_min / 60
       const angle = val.bearing_deg
 
+      //Move to rover on first odom message
+      if(!this.findRover){
+        this.findRover = true
+        this.center = L.latLng(lat, lng)
+      }
+      
       // Update the rover marker
       this.roverMarker.setRotationAngle(angle)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71604997/158074174-30f3c273-79fb-4869-a306-58fe656770be.png)
This is an example of the gui, this was done after sending one message with the rough coordinates of Ann Arbor. Now operators will not have to find the rover each time the gui is refreshed.