### PR TITLE
Added return to home, bound to H key

### DIFF
--- a/jetson/percep_obs_detect/include/viewer/viewer.hpp
+++ b/jetson/percep_obs_detect/include/viewer/viewer.hpp
@@ -195,6 +195,10 @@ class Viewer {
         bool inMenu = false;
         bool record = false;
         int currentFPS = -1;
+        glm::vec3 home_center{};
+        glm::vec3 home_offset{};
+        glm::vec3 home_orientation{};
+        float home_distance;
 
         // Creates a window
         Viewer();

--- a/jetson/percep_obs_detect/src/viewer/viewer.cpp
+++ b/jetson/percep_obs_detect/src/viewer/viewer.cpp
@@ -283,6 +283,13 @@ void PointCloud::swap(PointCloud& other) {
  */
 
 Viewer::Viewer() : camera(glm::perspectiveFov(glm::radians(35.0f), 1920.0f, 1080.0f, 0.1f, 100000.0f)) {
+    //get home orientations
+    home_center = camera.center; 
+    home_offset = camera.offset;
+    home_orientation.x = camera.eulerOrientation.x; 
+    home_orientation.y = camera.eulerOrientation.y + glm::radians(180.0);
+    home_orientation.z = camera.eulerOrientation.z;
+    home_distance = camera.distance;
 }
 
 void Viewer::initGraphics() {
@@ -399,6 +406,12 @@ void Viewer::keyCallback(GLFWwindow* window, int key, int scancode, int action, 
             case GLFW_KEY_R: {
                 viewer->record = !viewer->record;
                 break;
+            }
+            case GLFW_KEY_H: {
+                viewer->camera.center = viewer->home_center;
+                viewer->camera.offset = viewer->home_offset;
+                viewer->camera.eulerOrientation = viewer->home_orientation;
+                viewer->camera.distance = viewer->home_distance;
             }
         }
     }


### PR DESCRIPTION
Maintains initial "home" conditions, accessed via the 'H' key in GPU Obstacle Detection GUI