### PR TITLE
Additional checks regarding control state in IK

### DIFF
--- a/jetson/ra_kinematics/mrover_arm.hpp
+++ b/jetson/ra_kinematics/mrover_arm.hpp
@@ -247,6 +247,8 @@ protected:
     void check_dud_encoder(std::vector<double> &angles) const;
 
     void check_joint_limits(std::vector<double> &angles);
+
+    void set_to_closed_loop();
 };
 
 class StandardArm : public MRoverArm {

--- a/jetson/ra_kinematics/mrover_arm.hpp
+++ b/jetson/ra_kinematics/mrover_arm.hpp
@@ -249,6 +249,8 @@ protected:
     void check_joint_limits(std::vector<double> &angles);
 
     void set_to_closed_loop();
+
+    bool interrupt(ControlState expected_state, std::string action);
 };
 
 class StandardArm : public MRoverArm {


### PR DESCRIPTION
- Automatically set state to closed-loop when we tell the arm to move
- Safety check if closed-loop was aborted or other unexpected state is encountered before updating control state