### PR TITLE
[Auton-GUI] Added intermediate step between toggling auton mode

### DIFF
--- a/base_station/gui/src/components/AutonModeCheckbox.vue
+++ b/base_station/gui/src/components/AutonModeCheckbox.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="wrap-button">
-    <button v-bind:class="[color]" v-on:click='toggleAndEmit()'>
-      <span class='white-text'>{{name}}: {{active ? '\u2611' : '\u2610'}}</span>
+    <button v-bind:class="[this.color]" v-on:click='toggleAndEmit()'>
+      <span class='white-text'>{{name}}: <br>{{active ? '\u2611' : '\u2610'}}</span>
     </button>
   </div>
 </template>
@@ -18,14 +18,13 @@ export default {
     name: {
       type: String,
       required: true
+    },
+    color: {
+      type: String,
+      required: true
     }
   },
 
-  computed: {
-    color: function () {
-      return this.active ? 'green' : 'red'
-    }
-  },
 
   methods: {
     toggle: function () {
@@ -55,6 +54,10 @@ export default {
 
   .red {
     background-color: red;
+  }
+
+  .yellow {
+    background-color: #FFD700;
   }
 
   .white-text{

--- a/base_station/gui/src/components/WaypointEditor.vue
+++ b/base_station/gui/src/components/WaypointEditor.vue
@@ -42,7 +42,7 @@
     <div class="col-wrap" style="left: 50%">
       <div class="box datagrid">
         <div class="autonmode">
-          <Checkbox ref="checkbox" v-bind:name="'Autonomy Mode'" v-on:toggle="toggleAutonMode($event)"/>
+          <Checkbox ref="checkbox" v-bind:name="autonButtonText" v-bind:color="autonButtonColor"  v-on:toggle="toggleAutonMode($event)"/>
         </div>
         <div class="stats">
           <p>
@@ -65,7 +65,7 @@
 </template>
 
 <script>
-import Checkbox from './CheckboxBig.vue'
+import Checkbox from './AutonModeCheckbox.vue'
 import draggable from 'vuedraggable'
 import {convertDMS} from '../utils.js';
 import AutonJoystickReading from './AutonJoystickReading.vue'
@@ -116,7 +116,11 @@ export default {
       },
 
       storedWaypoints: [],
-      route: []
+      route: [],
+
+      autonButtonColor: "red",
+      waitingForNav: false
+
     }
   },
 
@@ -128,6 +132,16 @@ export default {
 
     this.$parent.subscribe('/nav_status', (msg) => {
       this.nav_status = msg
+      if(this.waitingForNav){
+        if(this.nav_status.nav_state_name!="Off" && this.autonEnabled){
+          this.waitingForNav = false
+          this.autonButtonColor = "green"
+        }
+        else if(this.nav_status.nav_state_name=="Off" && !this.autonEnabled){
+          this.waitingForNav = false
+          this.autonButtonColor = "red"
+        }
+      }
     })
 
     interval = window.setInterval(() => {
@@ -230,6 +244,8 @@ export default {
 
     toggleAutonMode: function (val) {
       this.setAutonMode(val)
+      this.autonButtonColor = "yellow"
+      this.waitingForNav = true;
     }
   },
 
@@ -288,7 +304,12 @@ export default {
 
     sec_enabled: function() {
       return this.odom_format == 'DMS';
+    },
+
+    autonButtonText: function() {
+      return (this.autonButtonColor == "yellow") ? "Setting to "+this.autonEnabled : "Autonomy Mode"
     }
+
   },
 
   components: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71604997/160960868-d9cd3c2a-6b14-4e12-8845-318f19bc4c0b.png)
Button will now turn yellow when toggling auton mode on or off and indicated which it is trying to be set to. After receiving a message with the proper nav status the button will turn red/green. Descriptions of behavior below.
Off -> On: the button will turn yellow and read "Setting to true", then turn green once a nav status other than "Off" is received.
On -> Off: the button will turn yellow and read "Setting to false", then turn red once an "Off" nav status is received.
Note that the button can still be clicked again while in a yellow state and it will switch to the other transition state.