### PR TITLE
Changed type of search_pattern_size member of /search_point struct fr…

### DIFF
--- a/base_station/gui/src/static/rover_msgs.json
+++ b/base_station/gui/src/static/rover_msgs.json
@@ -675,7 +675,7 @@
     ],
     "SearchPoints": [
         [
-            "size_t",
+            "int32_t",
             "search_pattern_size"
         ],
         [

--- a/rover_msgs/SearchPoints.lcm
+++ b/rover_msgs/SearchPoints.lcm
@@ -1,6 +1,6 @@
 package rover_msgs;
 
 struct SearchPoints {
-    size_t search_pattern_size;
+    int32_t search_pattern_size;
     Odometry points[search_pattern_size];
 }


### PR DESCRIPTION
Changed to Avoid error :
Array dimension 'search_pattern_size' must be an integer type.
/vagrant/rover_msgs/SearchPoints.lcm : 5
    Odometry points[search_pattern_size];

When building jetson/nav

