### PR TITLE
Fix motion planner to keep joints stationary if starting and target angles are the same

### DIFF
--- a/jetson/ra_kinematics/motion_planner.cpp
+++ b/jetson/ra_kinematics/motion_planner.cpp
@@ -184,10 +184,16 @@ MotionPlanner::Node* MotionPlanner::extend(ArmState &robot, Node* tree, const st
 
 MotionPlanner::Node* MotionPlanner::connect(ArmState &robot, Node* tree, const std::vector<double> &a_new) {
     Node* extension;
+    int ct = 0;
 
     do {
         extension = extend(robot, tree, a_new);
-    } while (extension && !vec_almost_equal(extension->config, a_new, VEC_ANGLE_EPSILON));
+        ++ct;
+    } while (extension && !vec_almost_equal(extension->config, a_new, VEC_ANGLE_EPSILON) && ct < 2000);
+
+    if (ct == 2000) {
+        std::cout << "Error: Motion planner connect exceeded 2000 iterations\n";
+    }
 
     return extension;
 }

--- a/jetson/ra_kinematics/motion_planner.hpp
+++ b/jetson/ra_kinematics/motion_planner.hpp
@@ -15,7 +15,7 @@
 using namespace Eigen;
 
 static constexpr int MAX_RRT_ITERATIONS = 500;
-static constexpr double VEC_ANGLE_EPSILON = 0.0000001;
+static constexpr double VEC_ANGLE_EPSILON = 0.0002;
 
 /**
  * Use rrt_connect() to map out a path to the target position.

--- a/jetson/ra_kinematics/mrover_arm.hpp
+++ b/jetson/ra_kinematics/mrover_arm.hpp
@@ -218,7 +218,7 @@ protected:
 
     virtual void send_kill_cmd() = 0;
 
-    void plan_path(ArmState& hypo_state, std::vector<double> &goal);
+    void plan_path(ArmState& hypo_state, const std::vector<double>& goal);
     
     void preview(ArmState& hypo_state);
 

--- a/jetson/ra_kinematics/mrover_arm.hpp
+++ b/jetson/ra_kinematics/mrover_arm.hpp
@@ -218,7 +218,7 @@ protected:
 
     virtual void send_kill_cmd() = 0;
 
-    void plan_path(ArmState& hypo_state, const std::vector<double> &goal);
+    void plan_path(ArmState& hypo_state, std::vector<double> &goal);
     
     void preview(ArmState& hypo_state);
 

--- a/jetson/ra_kinematics/utils.cpp
+++ b/jetson/ra_kinematics/utils.cpp
@@ -203,7 +203,7 @@ bool vec_almost_equal(const std::vector<double>& a, const std::vector<double>& b
         return false;
     }
     for (size_t i = 0; i < a.size(); ++i) {
-        if (abs(a[i] - b[i]) > epsilon) {
+        if (std::abs(a[i] - b[i]) > epsilon) {
             return false;
         }
     }


### PR DESCRIPTION
- Set target angle exactly equal to starting angle if they're close enough
- Change motion planner threshold to match threshold used in above
- Break out of motion planner if it takes too long
- A few missing `std::` scope specifiers