### PR TITLE
[percep -> nav] Use point cloud to better retrieve AR tag distance and bearing

### DIFF
--- a/config/percep/config.json
+++ b/config/percep/config.json
@@ -60,7 +60,7 @@
     "alvar_params":
     {
         "marker_border_bits": 1,
-        "do_corner_refinement": 0,
+        "do_corner_refinement": false,
         "polygonal_approx_accuracy_rate": 0.08
 
     }

--- a/jetson/percep/CMakeLists.txt
+++ b/jetson/percep/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Provided for convenience (syntax highlighting for CLion)
+# Use Meson in production as it is the officially suported build system
+cmake_minimum_required(VERSION 3.8)
+project(perception)
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(lcm REQUIRED)
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+find_package(OpenCV REQUIRED)
+find_package(ZED 2 REQUIRED)
+find_package(CUDA 11 REQUIRED)
+find_package(PCL REQUIRED)
+include(${LCM_USE_FILE})
+include_directories(/usr/local/include/lcm)
+include_directories(/usr/include/rapidjson)
+include_directories(${OpenCV_INCLUDE_DIRS})
+include_directories(${ZED_INCLUDE_DIRS})
+include_directories(${CUDA_INCLUDE_DIRS})
+
+file(GLOB_RECURSE LCM_FILES CONFIGURE_DEPENDS "../../rover_msgs/*.lcm")
+lcm_wrap_types(
+        C_EXPORT rover_lcm_types
+        C_SOURCES c_sources
+        C_HEADERS c_headers
+        CPP_HEADERS cpp_headers
+        ${LCM_FILES}
+)
+
+lcm_add_library(lcm_types CPP ${cpp_headers})
+target_include_directories(lcm_types INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+file(GLOB_RECURSE REMOVE_CMAKE "cmake-build*/*" "deprecated/*" "percep_test/*")
+list(REMOVE_ITEM SOURCE_FILES ${REMOVE_CMAKE})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} lcm_types lcm Eigen3::Eigen ${OpenCV_LIBS} ${ZED_LIBRARIES} ${CUDA_LIBRARIES} ${CUDA_npps_LIBRARY} ${CUDA_nppi_LIBRARY})

--- a/jetson/percep/artag_detector.cpp
+++ b/jetson/percep/artag_detector.cpp
@@ -140,20 +140,20 @@ pair<Tag, Tag> TagDetector::findARTags(Mat& src, Mat& depth_src, Mat& rgb) {  //
 }
 
 /***
- * Calculate value of final messages to broadcast: distance and bearing to targets.
+ * Calculate values of final messages to broadcast: AR tag distances and bearings relative to the rover.
  * We know the pixel positions of the AR tags, use those to retrieve the XYZ values from the point cloud.
  * Note: Output is not filtered whatsoever, do not expect consistent readings.
  *
- * @param outArTags     LCM network message to fill, used mainly by navigation
+ * @param outTags       LCM network message to fill, used mainly by navigation
  * @param tagPair       AR tag pixel positions and IDs
  * @param depth_img     TODO needed?
  * @param xyz_img       Point cloud XYZ data calculated from rectifying both images.
  */
-void TagDetector::updateDetectedTagInfo(rover_msgs::Target* outArTags, pair<Tag, Tag> const& tagPair, Mat const& depth_img, Mat const& xyz_img) const {
+void TagDetector::updateDetectedTagInfo(rover_msgs::Target* outTags, pair<Tag, Tag> const& tagPair, Mat const& depth_img, Mat const& xyz_img) const {
     array<Tag, 2> tags{tagPair.first, tagPair.second};
     for (size_t i = 0; i < 2; ++i) {
         Tag const& tag = tags[i];
-        rover_msgs::Target& outArTag = outArTags[i];
+        rover_msgs::Target& outArTag = outTags[i];
         if (tag.id == DEFAULT_TAG_VAL) {
             // no tag found
             outArTag.distance = DEFAULT_TAG_VAL;

--- a/jetson/percep/artag_detector.cpp
+++ b/jetson/percep/artag_detector.cpp
@@ -72,7 +72,7 @@ cv::Point2f TagDetector::getAverageTagCoordinateFromCorners(const std::vector<cv
  *                  The leftmost tag is always the first item in the pair,
  */
 std::pair<Tag, Tag> TagDetector::findARTags(cv::Mat& src, cv::Mat& depth_src, cv::Mat& rgb) {
-    cvtColor(src, rgb, cv::COLOR_RGBA2RGB);
+    cv::cvtColor(src, rgb, cv::COLOR_RGBA2RGB);
     // clear ids and corners vectors for each detection
     mIds.clear();
     mCorners.clear();
@@ -90,7 +90,7 @@ std::pair<Tag, Tag> TagDetector::findARTags(cv::Mat& src, cv::Mat& depth_src, cv
 
     // on click debugging for color
     DEPTH = depth_src;
-    cvtColor(rgb, HSV, cv::COLOR_RGB2HSV);
+    cv::cvtColor(rgb, HSV, cv::COLOR_RGB2HSV);
     cv::setMouseCallback("Obstacle", onMouse);
 #endif
 
@@ -164,8 +164,8 @@ void TagDetector::updateDetectedTagInfo(
             outArTag.id = DEFAULT_TAG_VAL;
         } else {
             // tag found
-            int xPixel = static_cast<int>(lround(tag.loc.x));
-            int yPixel = static_cast<int>(lround(tag.loc.y));
+            int xPixel = static_cast<int>(std::lround(tag.loc.x));
+            int yPixel = static_cast<int>(std::lround(tag.loc.y));
             // +z is forward, +x is right, all in millimeters and relative to camera
             float x, y, z;
             {
@@ -175,15 +175,15 @@ void TagDetector::updateDetectedTagInfo(
                 z = xyz[2];
             }
             // ensure we have valid values to work with
-            if (isnan(x) || isnan(y) || isnan(z)) {
+            if (std::isnan(x) || std::isnan(y) || std::isnan(z)) {
                 // put no tag found since we cannot find out any information
                 outArTag.distance = DEFAULT_TAG_VAL;
                 outArTag.bearing = DEFAULT_TAG_VAL;
                 outArTag.id = DEFAULT_TAG_VAL;
             } else {
                 // use Euclidean method to calculate distance, convert to meters
-                outArTag.distance = sqrt(x * x + y * y + z * z) * static_cast<float>(MM_PER_M);
-                outArTag.bearing = atan2(x, z) * 180.0 / PI;
+                outArTag.distance = std::sqrt(x * x + y * y + z * z) * static_cast<float>(MM_PER_M);
+                outArTag.bearing = std::atan2(x, z) * 180.0 / PI;
                 outArTag.id = tag.id;
             }
         }

--- a/jetson/percep/artag_detector.cpp
+++ b/jetson/percep/artag_detector.cpp
@@ -25,8 +25,8 @@ TagDetector::TagDetector(const rapidjson::Document& mRoverConfig) :
 
     cv::FileStorage fsr("jetson/percep/alvar_dict.yml", cv::FileStorage::READ);
     if (!fsr.isOpened()) {  //throw error if dictionary file does not exist
-        std::cerr << "ERR: \"alvar_dict.yml\" does not exist! Create it before running main\n";
-        throw cv::Exception();
+        std::cerr << "ERR: \"alvar_dict.yml\" does not exist! Create it before running main" << std::endl;
+        throw std::runtime_error("Dictionary does not exist");
     }
 
     // read dictionary from file
@@ -182,7 +182,8 @@ void TagDetector::updateDetectedTagInfo(
                 outArTag.id = DEFAULT_TAG_VAL;
             } else {
                 // use Euclidean method to calculate distance, convert to meters
-                outArTag.distance = std::sqrt(x * x + y * y + z * z) * static_cast<float>(MM_PER_M);
+                const float MM_TO_M = 0.001f;
+                outArTag.distance = std::sqrt(x * x + y * y + z * z) * MM_TO_M;
                 outArTag.bearing = std::atan2(x, z) * 180.0 / PI;
                 outArTag.id = tag.id;
             }

--- a/jetson/percep/artag_detector.cpp
+++ b/jetson/percep/artag_detector.cpp
@@ -14,10 +14,8 @@ void onMouse(int event, int x, int y, int flags, void* userdata) {
     }
 }
 
-//initializes detector object with pre-generated dictionary of tags 
+// initializes detector object with pre-generated dictionary of tags
 TagDetector::TagDetector(const rapidjson::Document& mRoverConfig) :
-
-//Populate Constants from Config File
         BUFFER_ITERATIONS{mRoverConfig["ar_tag"]["buffer_iterations"].GetInt()},
         MARKER_BORDER_BITS{mRoverConfig["alvar_params"]["marker_border_bits"].GetInt()},
         DO_CORNER_REFINEMENT{mRoverConfig["alvar_params"]["do_corner_refinement"].GetBool()},
@@ -32,54 +30,62 @@ TagDetector::TagDetector(const rapidjson::Document& mRoverConfig) :
     }
 
     // read dictionary from file
-    int mSize, mCBits;
+    int size, correctionBits;
     cv::Mat bits;
-    fsr["MarkerSize"] >> mSize;
-    fsr["MaxCorrectionBits"] >> mCBits;
+    fsr["MarkerSize"] >> size;
+    fsr["MaxCorrectionBits"] >> correctionBits;
     fsr["ByteList"] >> bits;
     fsr.release();
-    alvarDict = cv::aruco::getPredefinedDictionary(cv::aruco::DICT_4X4_50);
+    mAlvarDict = cv::aruco::getPredefinedDictionary(cv::aruco::DICT_4X4_50);
 
     // initialize other special parameters that we need to properly detect the URC (Alvar) tags
-    alvarParams = new cv::aruco::DetectorParameters();
-    alvarParams->markerBorderBits = MARKER_BORDER_BITS;
+    mAlvarParams = new cv::aruco::DetectorParameters();
+    mAlvarParams->markerBorderBits = MARKER_BORDER_BITS;
     //alvarParams->doCornerRefinement = DO_CORNER_REFINEMENT;
-    alvarParams->polygonalApproxAccuracyRate = POLYGONAL_APPROX_ACCURACY_RATE;
+    mAlvarParams->polygonalApproxAccuracyRate = POLYGONAL_APPROX_ACCURACY_RATE;
 }
 
+/***
+ * Given the four corners of an AR tag, calculate the center.
+ *
+ * @param corners Corners in camera pixel space of AR tag.
+ * @return        AR tag center in camera pixel space.
+ */
 Point2f TagDetector::getAverageTagCoordinateFromCorners(const vector<Point2f>& corners) {  //gets coordinate of center of tag
-    // RETURN:
-    // Point2f object containing the average location of the 4 corners
-    // of the passed-in tag
     Point2f avgCoord;
     for (auto& corner: corners) {
         avgCoord.x += corner.x;
         avgCoord.y += corner.y;
     }
-    avgCoord.x /= corners.size();
-    avgCoord.y /= corners.size();
+    avgCoord.x /= static_cast<float>(corners.size());
+    avgCoord.y /= static_cast<float>(corners.size());
     return avgCoord;
 }
 
+/***
+ * Try and detect AR tag markers from a camera frame.
+ *
+ * @param src       Raw camera RGBA data.
+ * @param depth_src Camera depth information, this is the z component of the vector representing the pixel in 3D space.
+ * @param rgb       Camera RGB data.
+ * @return          Pair of target objects, each object has an ID and pixel x and y position for the center of the tag.
+ *                  The leftmost tag is always the first item in the pair,
+ */
 pair<Tag, Tag> TagDetector::findARTags(Mat& src, Mat& depth_src, Mat& rgb) {  //detects AR tags in source Mat and outputs Tag objects for use in LCM
-    // RETURN:
-    // pair of target objects- each object has an x and y for the center,
-    // and the tag ID number return them such that the "leftmost" (x
-    // coordinate) tag is at index 0
     cvtColor(src, rgb, COLOR_RGBA2RGB);
     // clear ids and corners vectors for each detection
-    ids.clear();
-    corners.clear();
+    mIds.clear();
+    mCorners.clear();
 
-    // Find tags
-    cv::aruco::detectMarkers(rgb, alvarDict, corners, ids, alvarParams);
+    // find tags
+    cv::aruco::detectMarkers(rgb, mAlvarDict, mCorners, mIds, mAlvarParams);
 #if AR_RECORD
     cv::aruco::drawDetectedMarkers(rgb, corners, ids);
 #endif
 
 #if PERCEPTION_DEBUG
     // Draw detected tags
-    cv::aruco::drawDetectedMarkers(rgb, corners, ids);
+    cv::aruco::drawDetectedMarkers(rgb, mCorners, mIds);
     cv::imshow("AR Tags", rgb);
 
     // on click debugging for color
@@ -90,25 +96,23 @@ pair<Tag, Tag> TagDetector::findARTags(Mat& src, Mat& depth_src, Mat& rgb) {  //
 
     // create Tag objects for the detected tags and return them
     pair<Tag, Tag> discoveredTags;
-    if (ids.empty()) {
+    if (mIds.empty()) {
         // no tags found, return invalid objects with tag set to -1
         discoveredTags.first.id = DEFAULT_TAG_VAL;
-        discoveredTags.first.loc = Point2f();
         discoveredTags.second.id = DEFAULT_TAG_VAL;
-        discoveredTags.second.loc = Point2f();
-
-    } else if (ids.size() == 1) {  // exactly one tag found
-        discoveredTags.first.id = ids[0];
-        discoveredTags.first.loc = getAverageTagCoordinateFromCorners(corners[0]);
+    } else if (mIds.size() == 1) {
+        // exactly one tag found
+        discoveredTags.first.id = mIds[0];
+        discoveredTags.first.loc = getAverageTagCoordinateFromCorners(mCorners[0]);
         // set second tag to invalid object with tag as -1
         discoveredTags.second.id = DEFAULT_TAG_VAL;
-        discoveredTags.second.loc = Point2f();
-    } else if (ids.size() == 2) {  // exactly two tags found
+    } else if (mIds.size() == 2) {
+        // exactly two tags found
         Tag t0, t1;
-        t0.id = ids[0];
-        t0.loc = getAverageTagCoordinateFromCorners(corners[0]);
-        t1.id = ids[1];
-        t1.loc = getAverageTagCoordinateFromCorners(corners[1]);
+        t0.id = mIds[0];
+        t0.loc = getAverageTagCoordinateFromCorners(mCorners[0]);
+        t1.id = mIds[1];
+        t1.loc = getAverageTagCoordinateFromCorners(mCorners[1]);
         if (t0.loc.x < t1.loc.x) {  //if tag 0 is left of tag 1, put t0 first
             discoveredTags.first = t0;
             discoveredTags.second = t1;
@@ -116,13 +120,14 @@ pair<Tag, Tag> TagDetector::findARTags(Mat& src, Mat& depth_src, Mat& rgb) {  //
             discoveredTags.first = t1;
             discoveredTags.second = t0;
         }
-    } else {  // detected >=3 tags
+    } else {
+        // detected >=3 tags
         // return leftmost and rightmost detected tags to account for potentially seeing 2 of each tag on a post
         Tag t0, t1;
-        t0.id = ids[0];
-        t0.loc = getAverageTagCoordinateFromCorners(corners[0]);
-        t1.id = ids[ids.size() - 1];
-        t1.loc = getAverageTagCoordinateFromCorners(corners[ids.size() - 1]);
+        t0.id = mIds[0];
+        t0.loc = getAverageTagCoordinateFromCorners(mCorners[0]);
+        t1.id = mIds[mIds.size() - 1];
+        t1.loc = getAverageTagCoordinateFromCorners(mCorners[mIds.size() - 1]);
         if (t0.loc.x < t1.loc.x) {  //if tag 0 is left of tag 1, put t0 first
             discoveredTags.first = t0;
             discoveredTags.second = t1;
@@ -134,51 +139,50 @@ pair<Tag, Tag> TagDetector::findARTags(Mat& src, Mat& depth_src, Mat& rgb) {  //
     return discoveredTags;
 }
 
-void TagDetector::updateDetectedTagInfo(rover_msgs::Target* arTags, pair<Tag, Tag>& tagPair, Mat& depth_img, Mat& xyz_img, Mat& src) const {
-    struct tagPairs {
-        vector<int> ids;
-        vector<int> x_pixels;
-        vector<int> y_pixels;
-        vector<int> buf_counts;
-    };
-    tagPairs tags;
-
-    tags.ids.push_back(tagPair.first.id);
-    tags.x_pixels.push_back(static_cast<int>(tagPair.first.loc.x));
-    tags.y_pixels.push_back(static_cast<int>(tagPair.first.loc.y));
-    tags.ids.push_back(tagPair.second.id);
-    tags.x_pixels.push_back(static_cast<int>(tagPair.second.loc.x));
-    tags.y_pixels.push_back(static_cast<int>(tagPair.second.loc.y));
-    tags.buf_counts.push_back(0);
-    tags.buf_counts.push_back(0);
-
-    for (size_t i = 0; i < 2; i++) {
-        if (tags.ids[i] == DEFAULT_TAG_VAL) { // no tag found
-            if (tags.buf_counts[i] <= BUFFER_ITERATIONS) { // send buffered tag until tag is found
-                ++tags.buf_counts[i];
-            } else { // if still no tag found, set all stats to -1
-                arTags[i].distance = DEFAULT_TAG_VAL;
-                arTags[i].bearing = DEFAULT_TAG_VAL;
-                arTags[i].id = DEFAULT_TAG_VAL;
-            }
-        } else { // tag found
-            int y_pixel = tags.y_pixels.at(i);
-            int x_pixel = tags.x_pixels.at(i);
+/***
+ * Calculate value of final messages to broadcast: distance and bearing to targets.
+ * We know the pixel positions of the AR tags, use those to retrieve the XYZ values from the point cloud.
+ * Note: Output is not filtered whatsoever, do not expect consistent readings.
+ *
+ * @param outArTags     LCM network message to fill, used mainly by navigation
+ * @param tagPair       AR tag pixel positions and IDs
+ * @param depth_img     TODO needed?
+ * @param xyz_img       Point cloud XYZ data calculated from rectifying both images.
+ */
+void TagDetector::updateDetectedTagInfo(rover_msgs::Target* outArTags, pair<Tag, Tag> const& tagPair, Mat const& depth_img, Mat const& xyz_img) const {
+    array<Tag, 2> tags{tagPair.first, tagPair.second};
+    for (size_t i = 0; i < 2; ++i) {
+        Tag const& tag = tags[i];
+        rover_msgs::Target& outArTag = outArTags[i];
+        if (tag.id == DEFAULT_TAG_VAL) {
+            // no tag found
+            outArTag.distance = DEFAULT_TAG_VAL;
+            outArTag.bearing = DEFAULT_TAG_VAL;
+            outArTag.id = DEFAULT_TAG_VAL;
+        } else {
+            // tag found
+            int xPixel = static_cast<int>(lround(tag.loc.x));
+            int yPixel = static_cast<int>(lround(tag.loc.y));
+            // +z is forward, +x is right, all in millimeters and relative to camera
             float x, y, z;
             {
-                auto xyz = xyz_img.at<Vec4f>(y_pixel, x_pixel);
+                auto xyz = xyz_img.at<Vec4f>(yPixel, xPixel);
                 x = xyz[0];
                 y = xyz[1];
                 z = xyz[2];
             }
-            auto raw_depth = depth_img.at<float>(y_pixel, x_pixel);
-            if (!isnan(raw_depth)) {
-                arTags[i].distance = sqrt(x * x + y * y + z * z) * static_cast<float>(MM_PER_M);
+            // ensure we have valid values to work with
+            if (isnan(x) || isnan(y) || isnan(z)) {
+                // put no tag found since we cannot find out any information
+                outArTag.distance = DEFAULT_TAG_VAL;
+                outArTag.bearing = DEFAULT_TAG_VAL;
+                outArTag.id = DEFAULT_TAG_VAL;
+            } else {
+                // use Euclidean method to calculate distance, convert to meters
+                outArTag.distance = sqrt(x * x + y * y + z * z) * static_cast<float>(MM_PER_M);
+                outArTag.bearing = atan2(x, z) * 180.0 / PI;
+                outArTag.id = tag.id;
             }
-            // +z is forward, +x is right, all relative to camera
-            arTags[i].bearing = atan2(x, z);
-            arTags[i].id = tags.ids.at(i);
-            tags.buf_counts[i] = 0;
         }
     }
 }

--- a/jetson/percep/artag_detector.hpp
+++ b/jetson/percep/artag_detector.hpp
@@ -39,5 +39,5 @@ public:
     pair<Tag, Tag> findARTags(Mat& src, Mat& depth_src, Mat& rgb);
 
     //if AR tag found, updates distance, bearing, and id
-    void updateDetectedTagInfo(rover_msgs::Target* outArTags, pair<Tag, Tag> const& tagPair, Mat const& depth_img, Mat const& xyz_img) const;
+    void updateDetectedTagInfo(rover_msgs::Target* outTags, pair<Tag, Tag> const& tagPair, Mat const& depth_img, Mat const& xyz_img) const;
 };

--- a/jetson/percep/artag_detector.hpp
+++ b/jetson/percep/artag_detector.hpp
@@ -14,11 +14,11 @@ struct Tag {
 
 class TagDetector {
 private:
-    Ptr<cv::aruco::Dictionary> alvarDict;
-    Ptr<cv::aruco::DetectorParameters> alvarParams;
-    std::vector<int> ids;
-    std::vector<std::vector<cv::Point2f>> corners;
-    cv::Mat rgb;
+    Ptr<cv::aruco::Dictionary> mAlvarDict;
+    Ptr<cv::aruco::DetectorParameters> mAlvarParams;
+    std::vector<int> mIds;
+    std::vector<std::vector<cv::Point2f>> mCorners;
+    cv::Mat mRgb;
 
 public:
     //Constants:
@@ -33,11 +33,11 @@ public:
     explicit TagDetector(const rapidjson::Document& mRoverConfig);
 
     //takes detected AR tag and finds center coordinate for use with ZED                                                                 
-    Point2f getAverageTagCoordinateFromCorners(const vector<Point2f>& corners);
+    static Point2f getAverageTagCoordinateFromCorners(const vector<Point2f>& corners);
 
     //detects AR tags in a given Mat
     pair<Tag, Tag> findARTags(Mat& src, Mat& depth_src, Mat& rgb);
 
     //if AR tag found, updates distance, bearing, and id
-    void updateDetectedTagInfo(rover_msgs::Target* arTags, pair<Tag, Tag>& tagPair, Mat& depth_img, Mat& xyz_img, Mat& src) const;
+    void updateDetectedTagInfo(rover_msgs::Target* outArTags, pair<Tag, Tag> const& tagPair, Mat const& depth_img, Mat const& xyz_img) const;
 };

--- a/jetson/percep/artag_detector.hpp
+++ b/jetson/percep/artag_detector.hpp
@@ -17,7 +17,7 @@ private:
     Ptr<cv::aruco::Dictionary> alvarDict;
     Ptr<cv::aruco::DetectorParameters> alvarParams;
     std::vector<int> ids;
-    std::vector<std::vector<cv::Point2f> > corners;
+    std::vector<std::vector<cv::Point2f>> corners;
     cv::Mat rgb;
 
 public:
@@ -30,7 +30,7 @@ public:
     int DEFAULT_TAG_VAL;
 
     //constructor loads alvar dictionary data from file that defines tag bit configurations
-    TagDetector(const rapidjson::Document& mRoverConfig);
+    explicit TagDetector(const rapidjson::Document& mRoverConfig);
 
     //takes detected AR tag and finds center coordinate for use with ZED                                                                 
     Point2f getAverageTagCoordinateFromCorners(const vector<Point2f>& corners);
@@ -38,10 +38,6 @@ public:
     //detects AR tags in a given Mat
     pair<Tag, Tag> findARTags(Mat& src, Mat& depth_src, Mat& rgb);
 
-    //finds the angle from center given pixel coordinates              
-    double getAngle(float xPixel, float wPixel);
-
-    //if AR tag found, updates distance, bearing, and id                              
-    void updateDetectedTagInfo(rover_msgs::Target* arTags, pair<Tag, Tag>& tagPair, Mat& depth_img, Mat& src);
-
+    //if AR tag found, updates distance, bearing, and id
+    void updateDetectedTagInfo(rover_msgs::Target* arTags, pair<Tag, Tag>& tagPair, Mat& depth_img, Mat& xyz_img, Mat& src) const;
 };

--- a/jetson/percep/artag_detector.hpp
+++ b/jetson/percep/artag_detector.hpp
@@ -1,21 +1,19 @@
 #pragma once
 
 #include <vector>
+
 #include "perception.hpp"
 #include "rover_msgs/Target.hpp"
 
-using namespace std;
-using namespace cv;
-
 struct Tag {
-    Point2f loc;
+    cv::Point2f loc;
     int id;
 };
 
 class TagDetector {
 private:
-    Ptr<cv::aruco::Dictionary> mAlvarDict;
-    Ptr<cv::aruco::DetectorParameters> mAlvarParams;
+    cv::Ptr<cv::aruco::Dictionary> mAlvarDict;
+    cv::Ptr<cv::aruco::DetectorParameters> mAlvarParams;
     std::vector<int> mIds;
     std::vector<std::vector<cv::Point2f>> mCorners;
     cv::Mat mRgb;
@@ -33,11 +31,11 @@ public:
     explicit TagDetector(const rapidjson::Document& mRoverConfig);
 
     //takes detected AR tag and finds center coordinate for use with ZED                                                                 
-    static Point2f getAverageTagCoordinateFromCorners(const vector<Point2f>& corners);
+    static cv::Point2f getAverageTagCoordinateFromCorners(const std::vector<cv::Point2f>& corners);
 
     //detects AR tags in a given Mat
-    pair<Tag, Tag> findARTags(Mat& src, Mat& depth_src, Mat& rgb);
+    std::pair<Tag, Tag> findARTags(cv::Mat& src, cv::Mat& depth_src, cv::Mat& rgb);
 
     //if AR tag found, updates distance, bearing, and id
-    void updateDetectedTagInfo(rover_msgs::Target* outTags, pair<Tag, Tag> const& tagPair, Mat const& depth_img, Mat const& xyz_img) const;
+    void updateDetectedTagInfo(rover_msgs::Target* outTags, std::pair<Tag, Tag> const& tagPair, cv::Mat const& depth_img, cv::Mat const& xyz_img) const;
 };

--- a/jetson/percep/artag_detector.hpp
+++ b/jetson/percep/artag_detector.hpp
@@ -13,31 +13,35 @@ struct Tag {
 };
 
 class TagDetector {
-   private:
+private:
     Ptr<cv::aruco::Dictionary> alvarDict;
     Ptr<cv::aruco::DetectorParameters> alvarParams;
     std::vector<int> ids;
     std::vector<std::vector<cv::Point2f> > corners;
     cv::Mat rgb;
-    
-   public:
-   //Constants:
-   int BUFFER_ITERATIONS;
-   int MARKER_BORDER_BITS;
-   bool DO_CORNER_REFINEMENT;
-   double POLYGONAL_APPROX_ACCURACY_RATE;
-   int MM_PER_M;
-   int DEFAULT_TAG_VAL;
+
+public:
+    //Constants:
+    int BUFFER_ITERATIONS;
+    int MARKER_BORDER_BITS;
+    bool DO_CORNER_REFINEMENT;
+    double POLYGONAL_APPROX_ACCURACY_RATE;
+    int MM_PER_M;
+    int DEFAULT_TAG_VAL;
 
     //constructor loads alvar dictionary data from file that defines tag bit configurations
-    TagDetector(const rapidjson::Document &mRoverConfig);    
+    TagDetector(const rapidjson::Document& mRoverConfig);
+
     //takes detected AR tag and finds center coordinate for use with ZED                                                                 
-    Point2f getAverageTagCoordinateFromCorners(const vector<Point2f> &corners);
-    //detects AR tags in a given Mat     
-    pair<Tag, Tag> findARTags(Mat &src, Mat &depth_src, Mat &rgb);    
+    Point2f getAverageTagCoordinateFromCorners(const vector<Point2f>& corners);
+
+    //detects AR tags in a given Mat
+    pair<Tag, Tag> findARTags(Mat& src, Mat& depth_src, Mat& rgb);
+
     //finds the angle from center given pixel coordinates              
-    double getAngle(float xPixel, float wPixel);     
+    double getAngle(float xPixel, float wPixel);
+
     //if AR tag found, updates distance, bearing, and id                              
-    void updateDetectedTagInfo(rover_msgs::Target *arTags, pair<Tag, Tag> &tagPair, Mat &depth_img, Mat &src); 
-    
+    void updateDetectedTagInfo(rover_msgs::Target* arTags, pair<Tag, Tag>& tagPair, Mat& depth_img, Mat& src);
+
 };

--- a/jetson/percep/camera.cpp
+++ b/jetson/percep/camera.cpp
@@ -2,7 +2,7 @@
 #include "perception.hpp"
 
 #if OBSTACLE_DETECTION
-    #include <pcl/common/common_headers.h>
+#include <pcl/common/common_headers.h>
 #endif
 
 #if ZED_SDK_PRESENT
@@ -13,6 +13,7 @@
 #include <cassert>
 
 #pragma GCC diagnostic pop
+
 //Class created to implement all Camera class' functions
 //Abstracts away details of using Stereolab's camera interface
 //so we can just use a simple custom one
@@ -20,94 +21,106 @@
 //but can use sample images for testing
 class Camera::Impl {
 public:
-    Impl(const rapidjson::Document &config);
-    ~Impl();
-	bool grab();
+    explicit Impl(const rapidjson::Document& config);
 
-	cv::Mat image();
-	cv::Mat depth();
-    
+    ~Impl();
+
+    bool grab();
+
+    cv::Mat const& image();
+
+    cv::Mat const& depth();
+
+    cv::Mat const& xyz();
+
     //constants
     int THRESHOLD_CONFIDENCE;
 
-    #if OBSTACLE_DETECTION
+#if OBSTACLE_DETECTION
     void dataCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point_cloud);
-    #endif
-  
+#endif
+
 private:
-	sl::RuntimeParameters runtime_params_;
-	sl::Resolution image_size_;
-	sl::Camera zed_;
+    sl::RuntimeParameters runtime_params_;
+    sl::Resolution image_size_;
+    sl::Camera zed_;
 
-	sl::Mat image_zed_;
-	sl::Mat depth_zed_;
+    sl::Mat image_zed_;
+    sl::Mat depth_zed_;
+    sl::Mat xyz_zed_;
 
-	cv::Mat image_;
-	cv::Mat depth_;
+    cv::Mat image_;
+    cv::Mat depth_;
+    cv::Mat xyz_;
 };
 
-Camera::Impl::Impl(const rapidjson::Document &config) : THRESHOLD_CONFIDENCE(config["camera"]["threshold_confidence"].GetDouble()) {
-	sl::InitParameters init_params;
-	init_params.camera_resolution = sl::RESOLUTION::HD720; // default: 720p
-	init_params.depth_mode = sl::DEPTH_MODE::PERFORMANCE;
-	init_params.coordinate_units = sl::UNIT::METER;
-	init_params.camera_fps = 15;
-	// TODO change this below?
+Camera::Impl::Impl(const rapidjson::Document& config) : THRESHOLD_CONFIDENCE(config["camera"]["threshold_confidence"].GetInt()) {
+    sl::InitParameters init_params;
+    init_params.camera_resolution = sl::RESOLUTION::HD720; // default: 720p
+    init_params.depth_mode = sl::DEPTH_MODE::PERFORMANCE;
+    init_params.coordinate_units = sl::UNIT::METER;
+    init_params.camera_fps = 15;
+    // TODO change this below?
 
-	assert(this->zed_.open() == sl::ERROR_CODE::SUCCESS);
-  
+    assert(this->zed_.open() == sl::ERROR_CODE::SUCCESS);
+
     //Parameters for Positional Tracking
     init_params.coordinate_system = sl::COORDINATE_SYSTEM::RIGHT_HANDED_Y_UP; // Use a right-handed Y-up coordinate system
     //this->zed_.setCameraSettings(sl::VIDEO_SETTINGS::BRIGHTNESS, 1);
 
-	this->runtime_params_.confidence_threshold = THRESHOLD_CONFIDENCE;
-	
-    #if PERCEPTION_DEBUG
-        std::cout<<"ZED init success\n";
-    #endif
+    this->runtime_params_.confidence_threshold = THRESHOLD_CONFIDENCE;
+
+#if PERCEPTION_DEBUG
+    std::cout << "ZED init success\n";
+#endif
 
     this->runtime_params_.sensing_mode = sl::SENSING_MODE::STANDARD;
 
-	this->image_size_ = this->zed_.getCameraInformation().camera_resolution;
-	this->image_zed_.alloc(this->image_size_.width, this->image_size_.height,
-						   sl::MAT_TYPE::U8_C4);
-	this->image_ = cv::Mat(
-		this->image_size_.height, this->image_size_.width, CV_8UC4,
-		this->image_zed_.getPtr<sl::uchar1>(sl::MEM::CPU));
-	this->depth_zed_.alloc(this->image_size_.width, this->image_size_.height,
-		                   sl::MAT_TYPE::F32_C1);
-	this->depth_ = cv::Mat(
-		this->image_size_.height, this->image_size_.width, CV_32FC1,
-		this->depth_zed_.getPtr<sl::uchar1>(sl::MEM::CPU));
+    this->image_size_ = this->zed_.getCameraInformation().camera_configuration.resolution;
+    this->image_zed_.alloc(this->image_size_.width, this->image_size_.height, sl::MAT_TYPE::U8_C4);
+    this->image_ = cv::Mat(this->image_size_.height, this->image_size_.width, CV_8UC4,
+                           this->image_zed_.getPtr<sl::uchar1>(sl::MEM::CPU));
+    this->depth_zed_.alloc(this->image_size_.width, this->image_size_.height, sl::MAT_TYPE::F32_C1);
+    this->depth_ = cv::Mat(this->image_size_.height, this->image_size_.width, CV_32FC1,
+                           this->depth_zed_.getPtr<sl::uchar1>(sl::MEM::CPU));
+    // F32_C4 tuple format: (x, y, z, unused), assuming unused is due to memory alignment
+    this->xyz_zed_.alloc(this->image_size_.width, this->image_size_.height, sl::MAT_TYPE::F32_C4);
+    this->xyz_ = cv::Mat(this->image_size_.height, this->image_size_.width, CV_32FC4,
+                         this->xyz_zed_.getPtr<sl::uchar1>(sl::MEM::CPU));
 }
 
 bool Camera::Impl::grab() {
     return this->zed_.grab() == sl::ERROR_CODE::SUCCESS;
 }
 
-cv::Mat Camera::Impl::image() {
-	this->zed_.retrieveImage(this->image_zed_, sl::VIEW::LEFT, sl::MEM::CPU,
-							 this->image_size_);
-	return this->image_;
+cv::Mat const& Camera::Impl::image() {
+    this->zed_.retrieveImage(this->image_zed_, sl::VIEW::LEFT, sl::MEM::CPU, this->image_size_);
+    return this->image_;
 }
 
-cv::Mat Camera::Impl::depth() {
-    this->zed_.retrieveMeasure(this->depth_zed_, sl::MEASURE::DEPTH,  sl::MEM::CPU,  this->image_size_);
-	return this->depth_;
+cv::Mat const& Camera::Impl::depth() {
+    this->zed_.retrieveMeasure(this->depth_zed_, sl::MEASURE::DEPTH, sl::MEM::CPU, this->image_size_);
+    return this->depth_;
 }
 
-//This function convert a RGBA color packed into a packed RGBA PCL compatible format
+cv::Mat const& Camera::Impl::xyz() {
+    this->zed_.retrieveMeasure(xyz_zed_, sl::MEASURE::XYZ, sl::MEM::CPU, image_size_);
+    return xyz_;
+}
+
+//This function convert an RGBA color packed into a packed RGBA PCL compatible format
 inline float convertColor(float colorIn) {
-    uint32_t color_uint = *(uint32_t *) & colorIn;
-    unsigned char *color_uchar = (unsigned char *) &color_uint;
+    uint32_t color_uint = *(uint32_t*) &colorIn;
+    auto* color_uchar = (unsigned char*) &color_uint;
     color_uint = ((uint32_t) color_uchar[0] << 16 | (uint32_t) color_uchar[1] << 8 | (uint32_t) color_uchar[2]);
-    return *reinterpret_cast<float *> (&color_uint);
+    return *reinterpret_cast<float*> (&color_uint);
 }
 
 Camera::Impl::~Impl() {
     this->depth_zed_.free(sl::MEM::CPU);
     this->image_zed_.free(sl::MEM::CPU);
-	this->zed_.close();
+    this->xyz_zed_.free(sl::MEM::CPU);
+    this->zed_.close();
 }
 
 #if OBSTACLE_DETECTION
@@ -150,16 +163,16 @@ public:
     ~Impl();
     bool grab();
 
-    #if AR_DETECTION
+#if AR_DETECTION
     cv::Mat image();
     cv::Mat depth();
-    #endif
+#endif
 
-    #if OBSTACLE_DETECTION
+#if OBSTACLE_DETECTION
     void dataCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point_cloud);
     void pcl_write(const cv::String &filename, pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point_cloud);
 
-    #endif
+#endif
 
     void disk_record_init();
     void write_curr_frame_to_disk(cv::Mat rgb, cv::Mat depth, int counter);
@@ -187,10 +200,10 @@ Camera::Impl::~Impl() {
 }
 
 Camera::Impl::Impl(const rapidjson::Document &config) {
-  
+
     std::cout<<"Please input the folder path (there should be a rgb and depth existing in this folder): ";
     std::cin>>path;
-    #if AR_DETECTION
+#if AR_DETECTION
     rgb_path = path + "/rgb";
     depth_path = path + "/depth";
     rgb_dir = opendir(rgb_path.c_str() );
@@ -199,34 +212,34 @@ Camera::Impl::Impl(const rapidjson::Document &config) {
         return;
     }
 
-    #endif  
+#endif
 
-    #if OBSTACLE_DETECTION
+#if OBSTACLE_DETECTION
     pcd_path = path + "/pcl";
     pcd_dir = opendir(pcd_path.c_str() );
     if(NULL==pcd_dir) {
-        std::cerr<<"Input folder not exist\n";   
+        std::cerr<<"Input folder not exist\n";
         return;
   }
-  #endif
-  
+#endif
+
 
     // get the vector of image names, jpg/png for rgb files, .exr for depth files
     // we only read the rgb folder, and assume that the depth folder's images have the same name
     struct dirent *dp = NULL;
-    #if AR_DETECTION
-  
+#if AR_DETECTION
+
     std::unordered_set<std::string> img_tails({".exr", ".jpg"}); // for rgb
-    #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
         std::cout<<"Read image names\n";
-    #endif
+#endif
     do {
         errno = 0;
         if ((dp = readdir(rgb_dir)) != NULL) {
         std::string file_name(dp->d_name);
-        #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
             std::cout<<"file_name is "<<file_name<<std::endl;
-        #endif
+#endif
         if (file_name.size() < 5) continue; // the lengh of the tail str is at least 4
         std::string tail = file_name.substr(file_name.size()-4, 4);
         std::string head = file_name.substr(0, file_name.size()-4);
@@ -236,12 +249,12 @@ Camera::Impl::Impl(const rapidjson::Document &config) {
         }
     } while  (dp != NULL);
     std::sort(img_names.begin(), img_names.end());
-    #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
         std::cout<<"Read image names complete\n";
-    #endif
+#endif
     idx_curr_img = 0;
 
-    #endif
+#endif
 
 #if OBSTACLE_DETECTION
     dp = NULL;
@@ -249,29 +262,29 @@ Camera::Impl::Impl(const rapidjson::Document &config) {
 #if PERCEPTION_DEBUG
     std::cout<<"Read PCL image names\n";
 #endif
-  
+
 do{
     if ((dp = readdir(pcd_dir)) != NULL) {
         std::string file_name(dp->d_name);
-        #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
             std::cout<<"file_name is "<<file_name<<std::endl;
-        #endif
-      
+#endif
+
         // the lengh of the tail str is at least 4
         if (file_name.size() < 5) continue;
 
         pcd_names.push_back(file_name);
-      
+
     }
 
 } while (dp != NULL);
 
     std::sort(pcd_names.begin(), pcd_names.end());
-    #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
         std::cout<<"Read .pcd image names complete\n";
-    #endif
+#endif
     idx_curr_pcd_img = 0;
-    
+
 #endif
 }
 
@@ -279,21 +292,21 @@ bool Camera::Impl::grab() {
 
     bool end = true;
 
-    #if AR_DETECTION
+#if AR_DETECTION
     idx_curr_img++;
     if (idx_curr_img >= img_names.size()) {
         std::cout<<"Ran out of images\n";
         end = false;
     }
-    #endif
+#endif
 
-    #if OBSTACLE_DETECTION
+#if OBSTACLE_DETECTION
     idx_curr_pcd_img++;
     if (idx_curr_pcd_img >= pcd_names.size()-2) {
         std::cout<<"Ran out of images\n";
-        end = false;  
+        end = false;
     }
-    #endif
+#endif
     if(!end){
         exit(1);
     }
@@ -303,10 +316,10 @@ bool Camera::Impl::grab() {
 #if AR_DETECTION
 cv::Mat Camera::Impl::image() {
     std::string full_path = rgb_path + std::string("/") + (img_names[idx_curr_img]);
-    #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
         cout << img_names[idx_curr_img] << "\n";
         cout << full_path << "\n";
-    #endif
+#endif
     cv::Mat img = cv::imread(full_path.c_str(), CV_LOAD_IMAGE_COLOR);
     if (!img.data){
         std::cerr<<"Load image "<<full_path<< " error\n";
@@ -318,9 +331,9 @@ cv::Mat Camera::Impl::depth() {
     std::string rgb_name = img_names[idx_curr_img];
     std::string full_path = depth_path + std::string("/") +
                             rgb_name.substr(0, rgb_name.size()-4) + std::string(".exr");
-    #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
         std::cout<<full_path<<std::endl;
-    #endif
+#endif
     cv::Mat img = cv::imread(full_path.c_str(), cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
     if (!img.data){
         std::cerr<<"Load image "<<full_path<< " error\n";
@@ -382,26 +395,32 @@ void Camera::Impl::dataCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point
 
 #endif
 
-Camera::Camera(const rapidjson::Document &config) : 
-    impl_{new Camera::Impl(config)}, rgb_foldername{""}, depth_foldername{""}, pcl_foldername{""} , mRoverConfig( config ),
-            FRAME_WRITE_INTERVAL{mRoverConfig["camera"]["frame_write_interval"].GetInt()} {}
+Camera::Camera(const rapidjson::Document& config) :
+        impl_{new Camera::Impl(config)}, mRoverConfig(config),
+        FRAME_WRITE_INTERVAL{mRoverConfig["camera"]["frame_write_interval"].GetInt()} {}
 
 Camera::~Camera() {
-	delete this->impl_;
+    delete this->impl_;
 }
 
 bool Camera::grab() {
-	return this->impl_->grab();
+    return this->impl_->grab();
 }
 
 #if AR_DETECTION
-cv::Mat Camera::image() {
-	return this->impl_->image();
+
+cv::Mat const& Camera::image() {
+    return this->impl_->image();
 }
 
-cv::Mat Camera::depth() {
-	return this->impl_->depth();
+cv::Mat const& Camera::depth() {
+    return this->impl_->depth();
 }
+
+cv::Mat const& Camera::xyz() {
+    return this->impl_->xyz();
+}
+
 #endif
 
 #if OBSTACLE_DETECTION
@@ -433,9 +452,9 @@ void Camera::disk_record_init() {
 
 //Writes point cloud data to data folder specified in build tag 
 void pcl_write(const cv::String &filename, pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point_cloud){
-    #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
         std::cout << "name of path is: " << filename << endl;
-    #endif
+#endif
     try{ pcl::io::savePCDFileASCII (filename, *p_pcl_point_cloud); }
     catch (pcl::IOException &e){
         cout << e.what();

--- a/jetson/percep/camera.hpp
+++ b/jetson/percep/camera.hpp
@@ -1,45 +1,53 @@
 #pragma once
+
 #include "perception.hpp"
 #include "rapidjson/document.h"
 
 #if OBSTACLE_DETECTION
-	#include <pcl/common/common_headers.h>
+#include <pcl/common/common_headers.h>
 #endif
 
 class Camera {
 private:
-	class Impl;
-	Impl *impl_;
-	std::string rgb_foldername;
-	std::string depth_foldername;
-	std::string pcl_foldername;
-	cv::VideoWriter vidWrite;
+    class Impl;
+
+    Impl* impl_;
+    std::string rgb_foldername;
+    std::string depth_foldername;
+    std::string pcl_foldername;
+    cv::VideoWriter vidWrite;
 
     //reference to config file
     const rapidjson::Document& mRoverConfig;
-	
+
 public:
 
-	int FRAME_WRITE_INTERVAL;
+    int FRAME_WRITE_INTERVAL;
 
-	Camera(const rapidjson::Document &config);
-	~Camera();
+    explicit Camera(const rapidjson::Document& config);
 
-	bool grab();
+    ~Camera();
 
-	cv::Mat image();
-	cv::Mat depth();
-	
-	#if OBSTACLE_DETECTION
-	void getDataCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point_cloud);
-	#endif
+    bool grab();
 
-	#if WRITE_CURR_FRAME_TO_DISK && AR_DETECTION && OBSTACLE_DETECTION
-	void disk_record_init();
-	void write_curr_frame_to_disk(cv::Mat rgb, cv::Mat depth, pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point_cloud, int counter);
-	#endif
+    cv::Mat const& image();
 
-	void record_ar_init();
-	void record_ar(cv::Mat rgb);
-	void record_ar_finish();
+    cv::Mat const& depth();
+
+    cv::Mat const& xyz();
+
+#if OBSTACLE_DETECTION
+    void getDataCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point_cloud);
+#endif
+
+#if WRITE_CURR_FRAME_TO_DISK && AR_DETECTION && OBSTACLE_DETECTION
+    void disk_record_init();
+    void write_curr_frame_to_disk(cv::Mat rgb, cv::Mat depth, pcl::PointCloud<pcl::PointXYZRGB>::Ptr &p_pcl_point_cloud, int counter);
+#endif
+
+    void record_ar_init();
+
+    void record_ar(cv::Mat rgb);
+
+    void record_ar_finish();
 };

--- a/jetson/percep/main.cpp
+++ b/jetson/percep/main.cpp
@@ -7,40 +7,40 @@
 using namespace cv;
 using namespace std;
 using namespace std::chrono_literals;
- 
+
 int main() {
 
- /* --- Reading in Config File --- */
-  rapidjson::Document mRoverConfig;
-  ifstream configFile;
-  string configPath = getenv("MROVER_CONFIG");
-  configPath += "/config_percep/config.json";
-  configFile.open( configPath );
-  string config = "";
-  string setting;
-  while( configFile >> setting ) {
-    config += setting;
-  }
-  configFile.close();
-  mRoverConfig.Parse( config.c_str() );
+    /* --- Reading in Config File --- */
+    rapidjson::Document mRoverConfig;
+    ifstream configFile;
+    string configPath = getenv("MROVER_CONFIG");
+    configPath += "/config_percep/config.json";
+    configFile.open(configPath);
+    string config = "";
+    string setting;
+    while (configFile >> setting) {
+        config += setting;
+    }
+    configFile.close();
+    mRoverConfig.Parse(config.c_str());
 
-  /* --- Camera Initializations --- */
+    /* --- Camera Initializations --- */
     Camera cam(mRoverConfig);
     int iterations = 0;
     cam.grab();
 
-    #if PERCEPTION_DEBUG
-        namedWindow("depth", 2);
-    #endif
-    
-    #if AR_DETECTION
+#if PERCEPTION_DEBUG
+    namedWindow("depth", 2);
+#endif
+
+#if AR_DETECTION
     Mat rgb;
     Mat src = cam.image();
-    #endif
+#endif
 
-    #if WRITE_CURR_FRAME_TO_DISK && AR_DETECTION && OBSTACLE_DETECTION
-        cam.disk_record_init();
-    #endif
+#if WRITE_CURR_FRAME_TO_DISK && AR_DETECTION && OBSTACLE_DETECTION
+    cam.disk_record_init();
+#endif
 
     /* -- LCM Messages Initializations -- */
     lcm::LCM lcm_;
@@ -48,18 +48,18 @@ int main() {
     rover_msgs::Target* arTags = arTagsMessage.targetList;
     arTags[0].distance = mRoverConfig["ar_tag"]["default_tag_val"].GetInt();
     arTags[1].distance = mRoverConfig["ar_tag"]["default_tag_val"].GetInt();
-    
+
     rover_msgs::Obstacle obstacleMessage;
     obstacleMessage.bearing = 0;
     obstacleMessage.rightBearing = 0;
     obstacleMessage.distance = -1;
-    
+
     /* --- AR Tag Initializations --- */
     TagDetector detector(mRoverConfig);
     pair<Tag, Tag> tagPair;
-    
+
     /* --- Point Cloud Initializations --- */
-    #if OBSTACLE_DETECTION
+#if OBSTACLE_DETECTION
 
     PCL pointcloud(mRoverConfig);
     enum viewerType {
@@ -75,128 +75,129 @@ int main() {
     deque <bool> checkFalse(numChecks, false); //false deque to check our outliers deque against
     obstacle_return lastObstacle;
 
-    #endif
+#endif
 
-    /* --- AR Recording Initializations and Implementation--- */ 
-    
+    /* --- AR Recording Initializations and Implementation--- */
+
     time_t now = time(0);
     char* ltm = ctime(&now);
     string timeStamp(ltm);
 
-    #if AR_RECORD
+#if AR_RECORD
     //initializing ar tag videostream object
     cam.record_ar_init();
-    #endif
+#endif
 
-  /* --- Main Processing Stuff --- */
-  while (true) {
+    /* --- Main Processing Stuff --- */
+    while (true) {
         //Check to see if we were able to grab the frame
         if (!cam.grab()) break;
 
-        #if AR_DETECTION
+#if AR_DETECTION
         //Grab initial images from cameras
         Mat rgb;
         Mat src = cam.image();
         Mat depth_img = cam.depth();
-        #endif
+        Mat xyz_img = cam.xyz();
+#endif
 
-        #if OBSTACLE_DETECTION
+#if OBSTACLE_DETECTION
         //Update Point Cloud
         pointcloud.update();
         cam.getDataCloud(pointcloud.pt_cloud_ptr);
-        #endif
+#endif
 
-        #if WRITE_CURR_FRAME_TO_DISK && AR_DETECTION && OBSTACLE_DETECTION
+#if WRITE_CURR_FRAME_TO_DISK && AR_DETECTION && OBSTACLE_DETECTION
         int FRAME_WRITE_INTERVAL = mRoverConfig["camera"]["frame_write_interval"].GetInt();
             if (iterations % FRAME_WRITE_INTERVAL == 0) {
                 Mat rgb_copy = src.clone(), depth_copy = depth_img.clone();
-                #if PERCEPTION_DEBUG
+#if PERCEPTION_DEBUG
                     cout << "Copied correctly" << endl;
-                #endif
+#endif
                 cam.write_curr_frame_to_disk(rgb_copy, depth_copy, pointcloud.pt_cloud_ptr, iterations);
         }
-        #endif
+#endif
 
         /* --- AR Tag Processing --- */
         arTags[0].distance = mRoverConfig["ar_tag"]["default_tag_val"].GetInt();
         arTags[1].distance = mRoverConfig["ar_tag"]["default_tag_val"].GetInt();
-        #if AR_DETECTION
-            tagPair = detector.findARTags(src, depth_img, rgb);
-            #if AR_RECORD
-                cam.record_ar(rgb);
-            #endif
+#if AR_DETECTION
+        tagPair = detector.findARTags(src, depth_img, rgb);
+#if AR_RECORD
+        cam.record_ar(rgb);
+#endif
 
-            detector.updateDetectedTagInfo(arTags, tagPair, depth_img, src);
+        detector.updateDetectedTagInfo(arTags, tagPair, depth_img, xyz_img, src);
 
-        #if PERCEPTION_DEBUG && AR_DETECTION
-            imshow("depth", src);
-            waitKey(1);  
-        #endif
+#if PERCEPTION_DEBUG && AR_DETECTION
+        imshow("depth", src);
+        waitKey(1);
+#endif
 
-        #endif
+#endif
 
         /* --- Point Cloud Processing --- */
-        #if OBSTACLE_DETECTION && !WRITE_CURR_FRAME_TO_DISK
-        
-        #if PERCEPTION_DEBUG
-            //Update Original 3D Viewer
-            pointcloud.updateViewer(originalView);
-            cout<<"Original W: " <<pointcloud.pt_cloud_ptr->width<<" Original H: "<<pointcloud.pt_cloud_ptr->height<<endl;
-        #endif
+#if OBSTACLE_DETECTION && !WRITE_CURR_FRAME_TO_DISK
 
-        //Run Obstacle Detection
-        pointcloud.pcl_obstacle_detection();  
-        obstacle_return obstacleOutput (pointcloud.leftBearing, pointcloud.rightBearing, pointcloud.distance);
+#if PERCEPTION_DEBUG
+        //Update Original 3D Viewer
+        pointcloud.updateViewer(originalView);
+        cout<<"Original W: " <<pointcloud.pt_cloud_ptr->width<<" Original H: "<<pointcloud.pt_cloud_ptr->height<<endl;
+#endif
 
-        //Outlier Detection Processing
-        outliers.pop_back(); //Remove outdated outlier value
+    //Run Obstacle Detection
+    pointcloud.pcl_obstacle_detection();
+    obstacle_return obstacleOutput (pointcloud.leftBearing, pointcloud.rightBearing, pointcloud.distance);
 
-        if(pointcloud.leftBearing > 0.05 || pointcloud.leftBearing < -0.05)
-            outliers.push_front(true);//if an obstacle is detected in front
-        else 
-            outliers.push_front(false); //obstacle is not detected
+    //Outlier Detection Processing
+    outliers.pop_back(); //Remove outdated outlier value
 
-        if(outliers == checkTrue) //If past iterations see obstacles
-            lastObstacle = obstacleOutput;
-        else if (outliers == checkFalse) // If our iterations see no obstacles after seeing obstacles
-            lastObstacle = obstacleOutput;
+    if(pointcloud.leftBearing > 0.05 || pointcloud.leftBearing < -0.05)
+        outliers.push_front(true);//if an obstacle is detected in front
+    else
+        outliers.push_front(false); //obstacle is not detected
 
-        //Update LCM 
-        obstacleMessage.bearing = lastObstacle.leftBearing; // Update LCM bearing field
-        obstacleMessage.rightBearing = lastObstacle.rightBearing;
-        obstacleMessage.distance = lastObstacle.distance; // Update LCM distance field
-        #if PERCEPTION_DEBUG
-            cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!Path Sent: " << obstacleMessage.bearing << "\n";
-            cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!Distance Sent: " << obstacleMessage.distance << "\n";
-        #endif
+    if(outliers == checkTrue) //If past iterations see obstacles
+        lastObstacle = obstacleOutput;
+    else if (outliers == checkFalse) // If our iterations see no obstacles after seeing obstacles
+        lastObstacle = obstacleOutput;
 
-        #if PERCEPTION_DEBUG
-        //Update Processed 3D Viewer
-        pointcloud.updateViewer(newView);
-        #if PERCEPTION_DEBUG
-            cout<<"Downsampled W: " <<pointcloud.pt_cloud_ptr->width<<" Downsampled H: "<<pointcloud.pt_cloud_ptr->height<<endl;
-        #endif
-        #endif
-        
-        #endif
-        
+    //Update LCM
+    obstacleMessage.bearing = lastObstacle.leftBearing; // Update LCM bearing field
+    obstacleMessage.rightBearing = lastObstacle.rightBearing;
+    obstacleMessage.distance = lastObstacle.distance; // Update LCM distance field
+#if PERCEPTION_DEBUG
+        cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!Path Sent: " << obstacleMessage.bearing << "\n";
+        cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!Distance Sent: " << obstacleMessage.distance << "\n";
+#endif
+
+#if PERCEPTION_DEBUG
+    //Update Processed 3D Viewer
+    pointcloud.updateViewer(newView);
+#if PERCEPTION_DEBUG
+        cout<<"Downsampled W: " <<pointcloud.pt_cloud_ptr->width<<" Downsampled H: "<<pointcloud.pt_cloud_ptr->height<<endl;
+#endif
+#endif
+
+#endif
+
         /* --- Publish LCMs --- */
         lcm_.publish("/target_list", &arTagsMessage);
         lcm_.publish("/obstacle", &obstacleMessage);
 
-        #if !ZED_SDK_PRESENT
-            std::this_thread::sleep_for(0.2s); // Iteration speed control not needed when using camera 
-        #endif
-        
+#if !ZED_SDK_PRESENT
+        std::this_thread::sleep_for(0.2s); // Iteration speed control not needed when using camera
+#endif
+
         ++iterations;
-  }
+    }
 
 
     /* --- Wrap Things Up --- */
-    #if AR_RECORD
-        cam.record_ar_finish();
-    #endif
-  
+#if AR_RECORD
+    cam.record_ar_finish();
+#endif
+
     return 0;
 }
 

--- a/jetson/percep/main.cpp
+++ b/jetson/percep/main.cpp
@@ -1,23 +1,19 @@
+#include <deque>
+
 #include "perception.hpp"
 #include "rover_msgs/Target.hpp"
 #include "rover_msgs/TargetList.hpp"
-#include <unistd.h>
-#include <deque>
-
-using namespace cv;
-using namespace std;
-using namespace std::chrono_literals;
 
 int main() {
 
     /* --- Reading in Config File --- */
     rapidjson::Document mRoverConfig;
-    ifstream configFile;
-    string configPath = getenv("MROVER_CONFIG");
+    std::ifstream configFile;
+    std::string configPath = getenv("MROVER_CONFIG");
     configPath += "/config_percep/config.json";
     configFile.open(configPath);
-    string config = "";
-    string setting;
+    std::string config;
+    std::string setting;
     while (configFile >> setting) {
         config += setting;
     }
@@ -30,12 +26,12 @@ int main() {
     cam.grab();
 
 #if PERCEPTION_DEBUG
-    namedWindow("depth", 2);
+    cv::namedWindow("depth", 2);
 #endif
 
 #if AR_DETECTION
-    Mat rgb;
-    Mat src = cam.image();
+    cv::Mat rgb;
+    cv::Mat src = cam.image();
 #endif
 
 #if WRITE_CURR_FRAME_TO_DISK && AR_DETECTION && OBSTACLE_DETECTION
@@ -44,19 +40,19 @@ int main() {
 
     /* -- LCM Messages Initializations -- */
     lcm::LCM lcm_;
-    rover_msgs::TargetList arTagsMessage;
+    rover_msgs::TargetList arTagsMessage{};
     rover_msgs::Target* arTags = arTagsMessage.targetList;
     arTags[0].distance = mRoverConfig["ar_tag"]["default_tag_val"].GetInt();
     arTags[1].distance = mRoverConfig["ar_tag"]["default_tag_val"].GetInt();
 
-    rover_msgs::Obstacle obstacleMessage;
+    rover_msgs::Obstacle obstacleMessage{};
     obstacleMessage.bearing = 0;
     obstacleMessage.rightBearing = 0;
     obstacleMessage.distance = -1;
 
     /* --- AR Tag Initializations --- */
     TagDetector detector(mRoverConfig);
-    pair<Tag, Tag> tagPair;
+    std::pair<Tag, Tag> tagPair;
 
     /* --- Point Cloud Initializations --- */
 #if OBSTACLE_DETECTION
@@ -79,9 +75,9 @@ int main() {
 
     /* --- AR Recording Initializations and Implementation--- */
 
-    time_t now = time(0);
+    time_t now = time(nullptr);
     char* ltm = ctime(&now);
-    string timeStamp(ltm);
+    std::string timeStamp(ltm);
 
 #if AR_RECORD
     //initializing ar tag videostream object
@@ -95,10 +91,10 @@ int main() {
 
 #if AR_DETECTION
         //Grab initial images from cameras
-        Mat rgb;
-        Mat src = cam.image();
-        Mat depth_img = cam.depth();
-        Mat xyz_img = cam.xyz();
+        cv::Mat rgb;
+        cv::Mat src = cam.image();
+        cv::Mat depth_img = cam.depth();
+        cv::Mat xyz_img = cam.xyz();
 #endif
 
 #if OBSTACLE_DETECTION
@@ -131,7 +127,7 @@ int main() {
 
 #if PERCEPTION_DEBUG && AR_DETECTION
         imshow("depth", src);
-        waitKey(1);
+        cv::waitKey(1);
 #endif
 
 #endif

--- a/jetson/percep/main.cpp
+++ b/jetson/percep/main.cpp
@@ -127,7 +127,7 @@ int main() {
         cam.record_ar(rgb);
 #endif
 
-        detector.updateDetectedTagInfo(arTags, tagPair, depth_img, xyz_img, src);
+        detector.updateDetectedTagInfo(arTags, tagPair, depth_img, xyz_img);
 
 #if PERCEPTION_DEBUG && AR_DETECTION
         imshow("depth", src);


### PR DESCRIPTION
Previously we were using just the pixel information + camera FOV to calculate bearing. Distance was calculated using the depth, so it was actually inaccurate and would be worse the less aligned you were with the gate. Now the actual point cloud information from the ZED is being used to calculate both of these better.

The intent of these fixes were to improve the accuracy of nav's estimation of gate positions since it uses both of these values. They should still be filtered on nav's end.