### PR TITLE
[nav] Lower chance gate will be regenerated incorrectly

### DIFF
--- a/config/nav/config.json
+++ b/config/nav/config.json
@@ -81,7 +81,7 @@
 	},
 
 	"gate": {
-		"filterSize": 4,
+		"filterSize": 8,
         "filterProportion": 0.75
 	}
 }

--- a/jetson/nav/gate_search/gateStateMachine.cpp
+++ b/jetson/nav/gate_search/gateStateMachine.cpp
@@ -81,9 +81,9 @@ NavState GateStateMachine::run() {
                     ++mPathIndex;
                 }
             }
-            if (mPathIndex > 0) {
-                // This avoids the situation where you approach the gate parallel
-                // and rapidly try to switch approaching from either side
+            // This check avoids the situation where you approach the gate parallel
+            // and rapidly try to switch approaching from either side
+            if (mPathIndex > 1) {
                 if (env->hasNewPostUpdate() && env->hasGateLocation()) {
                     updateGateTraversalPath();
                 }


### PR DESCRIPTION
While the rover was going to the prep point it saw the target and regenerated an incorrect gate position. Try to mitigate this by:

1) Increasing the filter size from 4 to 8
2) Not allowing gate path regeneration while going to the prep point