### PR TITLE
[esw] fix cameras crashing

### DIFF
--- a/jetson/cameras/src/__main__.py
+++ b/jetson/cameras/src/__main__.py
@@ -11,11 +11,14 @@ __pipelines = [None] * 4
 ARGUMENTS_LOW = ['--headless', '--bitrate=300000', '--width=256', '--height=144']
 # 10.0.0.1 represents the ip of the main base station laptop
 # 10.0.0.2 represents the ip of the secondary science laptop
-ips_one_laptop = ["10.0.0.1:5000", "10.0.0.1:5001", "10.0.0.1:5002", "10.0.0.1:5003"]
-ips_two_laptops = ["10.0.0.1:5000", "10.0.0.1:5001", "10.0.0.2:5000", "10.0.0.2:5001"]
+
+auton_ips = ["10.0.0.1:5000", "10.0.0.1:5001", "10.0.0.1:5002", "10.0.0.1:5003"]
+erd_ips = ["10.0.0.1:5000", "10.0.0.1:5001", "10.0.0.1:5002", "10.0.0.1:5003"]
+es_ips = ["10.0.0.1:5000", "10.0.0.1:5001", "10.0.0.1:5002", "10.0.0.1:5003"]
+science_ips = ["10.0.0.1:5000", "10.0.0.1:5001", "10.0.0.2:5000", "10.0.0.2:5001"]
 
 using_two_laptops = False
-current_ips = ips_two_laptops
+current_ips = science_ips
 
 video_sources = [None] * 10
 


### PR DESCRIPTION
Added a try/exception when trying to capture and render image. If capture and rendering the image from one camera fails, it will stop streaming to that camera. The program should theoretically not crash. The operator the GUI will not have any way of telling that the program stopped streaming that camera other than by looking at the feed itself (all the other cameras should still be working). Since the program theoretically no longer crashes, the operator should be able to quickly reopen that particular camera.

Camera code is very similar to what's in #1098. This is untested but hopefully it will prevent crashing.