### PR TITLE
[sim] Added 2dsim feature to ignore auton drive control with a button + updated sim to the new enable interface

### DIFF
--- a/simulators/nav/src/components/HotKeys.vue
+++ b/simulators/nav/src/components/HotKeys.vue
@@ -48,6 +48,9 @@ export default class HotKeys extends Vue {
   private readonly simulatePercep!:boolean;
 
   @Getter
+  private readonly simulateAutonDriveControl!:boolean;
+
+  @Getter
   private readonly zedGimbalPos!:ZedGimbalPosition;
 
   /************************************************************************************************
@@ -61,6 +64,9 @@ export default class HotKeys extends Vue {
 
   @Mutation
   private readonly flipSimulatePercep!:(onOff:boolean)=>void;
+
+  @Mutation
+  private readonly flipSimulateAutonDriveControl!:(onOff:boolean)=>void;
 
   @Mutation
   private readonly setAutonState!:(onOff:boolean)=>void;
@@ -122,6 +128,7 @@ export default class HotKeys extends Vue {
       'shift+ctrl+c': this.resetStartLoc,
       'shift+l': this.flipSimLoc,
       'shift+p': this.flipSimPercep,
+      'shift+d': this.flipSimAutonDriveControl,
       'shift+alt+d': this.setToDFormat,
       'shift+alt+m': this.setToDMFormat,
       'shift+alt+s': this.setToDMSFormat,
@@ -151,6 +158,11 @@ export default class HotKeys extends Vue {
   private flipSimPercep():void {
     this.flipSimulatePercep(!this.simulatePercep);
   } /* flipSimPercep() */
+
+  /* Turn on and off simulating auton drive control. */
+  private flipSimAutonDriveControl():void {
+    this.flipSimulateAutonDriveControl(!this.simulateAutonDriveControl);
+  } /* flipSimAutonDriveControl() */
 
   /* Apply one joystick command based on "manual" input. */
   private manaulDrive(forwardBack:number, leftRight:number):void {

--- a/simulators/nav/src/components/NavSimulator.vue
+++ b/simulators/nav/src/components/NavSimulator.vue
@@ -152,6 +152,9 @@ export default class NavSimulator extends Vue {
   private readonly simulatePercep!:boolean;
 
   @Getter
+  private readonly simulateAutonDriveControl!:boolean;
+
+  @Getter
   private readonly enableLCM!:boolean;
 
   @Getter
@@ -388,7 +391,7 @@ export default class NavSimulator extends Vue {
             forward_back: msg.message.left_percent_velocity,
             left_right: msg.message.right_percent_velocity
           });
-          if (!this.paused) {
+          if (!this.paused && this.simulateAutonDriveControl) {
             this.applyJoystickCmd();
           }
         }

--- a/simulators/nav/src/components/NavSimulator.vue
+++ b/simulators/nav/src/components/NavSimulator.vue
@@ -439,7 +439,6 @@ export default class NavSimulator extends Vue {
 
       /* Subscriptions */
       [
-        { topic: '/autonomous',     type: 'Joystick' },
         { topic: '/auton_drive_control',     type: 'AutonDriveControl' },
         { topic: '/nav_status',     type: 'NavStatus' },
         { topic: '/obstacle_list',  type: 'ObstacleList' },
@@ -454,7 +453,7 @@ export default class NavSimulator extends Vue {
 
     /* Set up publishing LCMs */
     this.intervalLcmPublish = window.setInterval(() => {
-      this.publish('/auton', { type: 'AutonState', is_auton: this.autonOn }, false);
+      this.publish('/auton_enabled', { type: 'Enable', enabled: this.autonOn }, false);
 
       if (this.simulateLoc) {
         const odom:any = Object.assign(this.currOdom, { type: 'Odometry' });

--- a/simulators/nav/src/components/control_panel/SimSettings.vue
+++ b/simulators/nav/src/components/control_panel/SimSettings.vue
@@ -38,6 +38,13 @@
               @clicked="flipSimulatePercep(!simulatePercep)"
             />
           </div>
+          <div class="setting">
+            <Checkbox
+              :on="simulateAutonDriveControl"
+              name="Simulate Auton Drive"
+              @clicked="flipSimulateAutonDriveControl(!simulateAutonDriveControl)"
+            />
+          </div>
         </div>
         <div class="columnRight">
           <div class="container">
@@ -147,6 +154,9 @@ export default class SimSettings extends Vue {
   private readonly simulatePercep!:boolean;
 
   @Getter
+  private readonly simulateAutonDriveControl!:boolean;
+
+  @Getter
   private readonly noisePercent!:number;
 
   @Getter
@@ -185,6 +195,9 @@ export default class SimSettings extends Vue {
 
   @Mutation
   private readonly flipSimulatePercep!:(onOff:boolean)=>void;
+
+  @Mutation
+  private readonly flipSimulateAutonDriveControl!:(onOff:boolean)=>void;
 
   @Mutation
   private readonly setNoisePercent!:(newNoisePercent:number)=>void;

--- a/simulators/nav/src/store/modules/simulatorState.ts
+++ b/simulators/nav/src/store/modules/simulatorState.ts
@@ -72,6 +72,7 @@ export const state:SimulatorState = {
   simSettings: {
     simulateLoc: true,
     simulatePercep: true,
+    simulateAutonDriveControl: true,
     enableLCM: true,
     enableFOVView: false,
     enableProjectedPoints: false,
@@ -129,6 +130,9 @@ const getters = {
 
   simulatePercep: (simState:SimulatorState):boolean => simState.simSettings.simulatePercep,
 
+  simulateAutonDriveControl:
+  (simState:SimulatorState):boolean => simState.simSettings.simulateAutonDriveControl,
+
   noisePercent: (simState:SimulatorState):number => simState.simSettings.noisePercent,
 
   noiseGPSPercent: (simState:SimulatorState):number => simState.simSettings.noiseGPSPercent,
@@ -182,6 +186,10 @@ const mutations = {
 
   flipSimulatePercep: (simState:SimulatorState, onOff:boolean):void => {
     simState.simSettings.simulatePercep = onOff;
+  },
+
+  flipSimulateAutonDriveControl: (simState:SimulatorState, onOff:boolean):void => {
+    simState.simSettings.simulateAutonDriveControl = onOff;
   },
 
   setNoisePercent: (simState:SimulatorState, newNoisePercent:number):void => {

--- a/simulators/nav/src/utils/types.ts
+++ b/simulators/nav/src/utils/types.ts
@@ -283,6 +283,7 @@ export interface RoverState {
 export interface SimulationSettings {
   simulateLoc:boolean;
   simulatePercep:boolean;
+  simulateAutonDriveControl:boolean;
   enableProjectedPoints:boolean;
   noisePercent:number;
   noiseGPSPercent:number;


### PR DESCRIPTION
https://user-images.githubusercontent.com/71047773/178129199-fa585e46-e113-45a0-8d0c-e993342a2793.mov

Added a toggle in the current sim that freezes the rover. When 'simulating auton drive control' is turned off, the sim ignores values from the drive LCM and sets the rover velocity to 0.

This old [PR](https://github.com/umrover/mrover-workspace/pull/1115) that updated sim to the new enable interface probably got lost while merging into main. I have added the same changes in this PR