### PR TITLE
[admin] Upgrade Java to target 1.6 for lcm-java

### DIFF
--- a/3rdparty/lcm/lcm-java/Makefile.am
+++ b/3rdparty/lcm/lcm-java/Makefile.am
@@ -6,7 +6,7 @@ xmlgraphics_jar = $(srcdir)/jchart2d-code/ext/xmlgraphics-commons-1.3.1.jar
 abs_jchart2d_src_dir = $(abs_srcdir)/jchart2d-code/src
 abs_jide_jar = $(abs_srcdir)/jchart2d-code/ext/jide-oss-2.9.7.jar
 abs_xmlgraphics_jar = $(abs_srcdir)/jchart2d-code/ext/xmlgraphics-commons-1.3.1.jar
-JAVACFLAGS = -source 1.5 -target 1.5 -classpath $(abs_jide_jar):$(abs_xmlgraphics_jar):$(abs_jchart2d_src_dir)
+JAVACFLAGS = -source 1.6 -target 1.6 -classpath $(abs_jide_jar):$(abs_xmlgraphics_jar):$(abs_jchart2d_src_dir)
 
 .PHONY classfiles: classdist_noinst.stamp classnoinst.stamp
 

--- a/3rdparty/lcm/lcm-java/build.xml
+++ b/3rdparty/lcm/lcm-java/build.xml
@@ -36,7 +36,7 @@
   debug="on"
   optimize="off"
   destdir="build"
-  source="1.5">
+  source="1.6">
 </javac>
 </target>
 


### PR DESCRIPTION
This change may be needed since `./jarvis build` did not work after running `./jarvis clean` on the Rocker base station laptop. After making this change, I was able to successfully build.

There are some other references to 1.5 (the old target that did not work) in other sections of the code. However, I am pretty sure the only necessary change needed to be made is in `JAVACFLAGS = -source 1.6 -target 1.6`. If I look at [this](https://github.com/lcm-proj/lcm/pull/138/files) similar PR for a different project, they ran into the same issue and they did not even change the build.xml file.

Let me know if I should just revert the build.xml file to 1.5 or something else. Either way, this fixes an issue.